### PR TITLE
Build MMRTree from RSK blocks

### DIFF
--- a/submitter/.gitignore
+++ b/submitter/.gitignore
@@ -3,5 +3,5 @@ regtest.json
 development.json
 test.json
 submitter.log
-lib/services/rsk/RskMMR.json
+src/services/rsk/RskMMR.json
 test/rsk/RskMMR.json

--- a/submitter/.gitignore
+++ b/submitter/.gitignore
@@ -3,3 +3,5 @@ regtest.json
 development.json
 test.json
 submitter.log
+lib/services/rsk/RskMMR.json
+test/rsk/RskMMR.json

--- a/submitter/.gitignore
+++ b/submitter/.gitignore
@@ -4,4 +4,4 @@ development.json
 test.json
 submitter.log
 src/services/rsk/RskMMR.json
-test/rsk/RskMMR.json
+test/services/rsk/RskMMR.json

--- a/submitter/config.sample.js
+++ b/submitter/config.sample.js
@@ -4,4 +4,6 @@ module.exports = {
     runEvery: 1, // In minutes,
     mmrSyncInterval: 30, // In minutes
     confirmations: 0,
+    mmrBlockConfirmations: 10,
+    rskMMRStoragePath: './src/services/rsk'
 }

--- a/submitter/package.json
+++ b/submitter/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "node ./src/main.js",
-    "test": "mocha --recursive",
+    "test": "mocha test/**/*.test.js --recursive",
     "mmrsync": "node ./src/mmrSync.js"
   },
   "keywords": [

--- a/submitter/package.json
+++ b/submitter/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "node ./src/main.js",
     "test": "mocha test/**/*.test.js --recursive",
-    "mmrsync": "node ./src/mmrSync.js"
+    "mmrsync": "node --max-old-space-size=2048 ./src/mmrSync.js"
   },
   "keywords": [
     "rsk",

--- a/submitter/src/lib/mmr/MMRNode.js
+++ b/submitter/src/lib/mmr/MMRNode.js
@@ -53,6 +53,21 @@ module.exports = class MMRNode {
         return newNode;
     }
 
+    static fromValues(block) {
+        let newNode = new MMRNode();
+        newNode.hash = block.hash;
+        newNode.left = null;
+        newNode.right = null;
+        newNode.start_height = block.start_height;
+        newNode.end_height = block.end_height;
+        newNode.start_time = block.start_time;
+        newNode.end_time = block.end_time;
+        newNode.start_difficulty = new BN(block.start_difficulty);
+        newNode.end_difficulty = new BN(block.end_difficulty);
+        newNode.total_difficulty = new BN(block.total_difficulty);
+        return newNode;
+    }
+
     isLeaf() {
         return this.left == null;
     }
@@ -80,6 +95,6 @@ module.exports = class MMRNode {
 
     toString() {
         return `{ hash:${this.hash}, start_height:${this.start_height}, end_height:${this.end_height}, ` +
-        `left:${this.left.hash}, right:${this.right.hash} }`;
+        `left:${this.left ? this.left.hash : null}, right:${this.right ? this.right.hash : null} }`;
     }
 }

--- a/submitter/src/lib/mmr/MMRTree.js
+++ b/submitter/src/lib/mmr/MMRTree.js
@@ -85,6 +85,49 @@ module.exports = class MMRTree {
         if(hashValue == rootHash) {
             return true;
         }
-        return false;        
+        return false;
+    }
+
+    serialize() {
+        let root = this.getRoot();
+        let tree = [];
+
+        this._serializeTree(root, tree);
+        return tree;
+    }
+
+    deserialize(serialized) {
+        this.root = this._deserializeTree(serialized);
+    }
+
+    // Recursive function to get the MMRTree as a list of nodes
+    _serializeTree(root, list) {
+        if (root === null) {
+            list.push(-1);
+            return;
+        }
+
+        list.push(root);
+
+        this._serializeTree(root.left, list);
+        this._serializeTree(root.right, list);
+    }
+
+    // Recursive function to restore a serialized list into a tree of MMRNode leaves
+    _deserializeTree(serialized = []) {
+        if (!serialized.length) {
+            return null;
+        }
+
+        let node = serialized.shift();
+        if (node === -1) {
+            return null;
+        }
+        let root = MMRNode.fromValues(node);
+
+        root.left = this._deserializeTree(serialized)
+        root.right = this._deserializeTree(serialized)
+
+        return root;
     }
 }

--- a/submitter/src/lib/mmr/MMRTree.js
+++ b/submitter/src/lib/mmr/MMRTree.js
@@ -96,38 +96,24 @@ module.exports = class MMRTree {
         return tree;
     }
 
-    deserialize(serialized) {
-        this.root = this._deserializeTree(serialized);
+    // Builds up a serialized list into the current MMRTree
+    deserialize(serialized = []) {
+        for (let node of serialized) {
+            let leaf = MMRNode.fromValues(node);
+            this._appendLeaf(leaf);
+        };
     }
 
-    // Recursive function to get the MMRTree as a list of nodes
+    // Recursive function to get the MMRTree as a list of leaves
     _serializeTree(root, list) {
         if (root === null) {
-            list.push(-1);
             return;
         }
-
-        list.push(root);
+        if (root.left === null && root.right === null) {
+            list.push(root);
+        }
 
         this._serializeTree(root.left, list);
         this._serializeTree(root.right, list);
-    }
-
-    // Recursive function to restore a serialized list into a tree of MMRNode leaves
-    _deserializeTree(serialized = []) {
-        if (!serialized.length) {
-            return null;
-        }
-
-        let node = serialized.shift();
-        if (node === -1) {
-            return null;
-        }
-        let root = MMRNode.fromValues(node);
-
-        root.left = this._deserializeTree(serialized)
-        root.right = this._deserializeTree(serialized)
-
-        return root;
     }
 }

--- a/submitter/src/lib/utils.js
+++ b/submitter/src/lib/utils.js
@@ -19,7 +19,7 @@ async function sleep(ms) {
 
 function hexStringToBuffer(hexString) {
     return ethUtils.toBuffer(ethUtils.addHexPrefix(hexString));
-}  
+}
 
 function stripHexPrefix(str) {
     return (str.indexOf('0x') == 0) ? str.slice(2) : str;
@@ -29,10 +29,17 @@ function privateToAddress(privateKey) {
     return ethUtils.bufferToHex(ethUtils.privateToAddress(this.hexStringToBuffer(privateKey)));
 }
 
-module.exports = { 
+// Returns current memory allocated in MB
+function memoryUsage() {
+    let { heapUsed } = process.memoryUsage();
+    return Math.round(heapUsed / (1024 * 1024));
+}
+
+module.exports = {
     waitBlocks: waitBlocks,
     sleep: sleep,
     hexStringToBuffer: hexStringToBuffer,
     privateToAddress: privateToAddress,
-    stripHexPrefix: stripHexPrefix
+    stripHexPrefix: stripHexPrefix,
+    memoryUsage: memoryUsage
 }

--- a/submitter/src/mmrSync.js
+++ b/submitter/src/mmrSync.js
@@ -36,7 +36,7 @@ async function run() {
 process.stdin.resume(); // so the program will not close instantly
 
 async function exitHandler() {
-    rskMMR.exitHandler();
+    await rskMMR.exitHandler();
 
     process.exit();
 }

--- a/submitter/src/mmrSync.js
+++ b/submitter/src/mmrSync.js
@@ -8,12 +8,10 @@ log4js.configure(logConfig);
 // Services
 const Scheduler = require('./services/Scheduler.js');
 const RskMMR = require('./services/rsk/RskMMR.js');
-const { memoryUsage } = require('./lib/utils');
 
 const logger = log4js.getLogger('main');
 logger.info('RSK Host', config.rsk.host);
 logger.info('ETH Host', config.eth.host);
-logger.debug(`Initial allocated memory: ${memoryUsage()} MB`);
 
 const rskMMR = new RskMMR(config, log4js.getLogger('RSK-MMR'));
 

--- a/submitter/src/services/rsk/RskMMR.js
+++ b/submitter/src/services/rsk/RskMMR.js
@@ -3,19 +3,19 @@ const fs = require('fs');
 const MMRTree = require('../../lib/mmr/MMRTree');
 const abiMMR = require('../../abis/MMR.json');
 const TransactionSender = require('../../lib/TransactionSender.js');
-const { memoryUsage } = require('../../lib/utils');
 
-const initialSeries = 50;
+const initialSeries = 1000;
 
 module.exports = class RskMMR {
     constructor(config, logger) {
         this.config = config;
         this.logger = logger;
 
-        this.rskWeb3 = new Web3(this.config.rsk.host);
-        this.mmrTree = this._restoreMMRTree();
         this.rskMMRPath = `${config.rskMMRStoragePath || __dirname}/RskMMR.json`;
         this.requiredConfirmations = config.mmrBlockConfirmations || 10;
+
+        this.rskWeb3 = new Web3(this.config.rsk.host);
+        this.mmrTree = this._restoreMMRTree();
     }
 
     async run() {
@@ -39,8 +39,8 @@ module.exports = class RskMMR {
             let mmrTree = new MMRTree();
 
             if (fs.existsSync(this.rskMMRPath)) {
-                let serialized = fs.readFileSync(this.rskMMRPath);
-                mmrTree.deserialize(JSON.parse(serialized));
+                let serialized = this._readFromFile(this.rskMMRPath);
+                mmrTree.deserialize(serialized);
 
                 this.logger.debug('MMRTree restored');
             }
@@ -59,8 +59,7 @@ module.exports = class RskMMR {
 
             let series = initialSeries;
 
-            this.logger.debug(`Getting blocks from ${lastMRRBlock} to ${blockAcceptance}`);
-            console.time('MMR Sync');
+            this.logger.debug(`Available blocks from ${lastMRRBlock} to ${blockAcceptance}`);
 
             while (lastMRRBlock < blockAcceptance) {
                 if (lastMRRBlock + series > blockAcceptance) {
@@ -78,11 +77,10 @@ module.exports = class RskMMR {
                     await this.mmrTree.appendBlock(block);
                 });
 
+                this.logger.debug(`Added blocks from ${lastMRRBlock} to ${lastMRRBlock + series}`);
+
                 lastMRRBlock = lastMRRBlock + series;
             }
-
-            console.timeEnd('MMR Sync');
-            this.logger.debug(`Current allocated memory: ${memoryUsage()} MB`);
 
         } catch (err) {
             this.logger.error('Exception updating MRRTree ', err);
@@ -117,14 +115,39 @@ module.exports = class RskMMR {
         return 0;
     }
 
-    exitHandler() {
+    async exitHandler() {
         try {
             let serializedTree = this.mmrTree.serialize();
-            fs.writeFileSync(this.rskMMRPath, JSON.stringify(serializedTree));
+            await this._writeToFile(this.rskMMRPath, serializedTree); // TODO append new blocks only
+
             this.logger.debug('MMRTree saved');
         } catch (err) {
             this.logger.error('Failed to save mmr tree', err);
         }
+    }
+
+    _writeToFile(filePath, arr) {
+        return new Promise((resolve, reject) => {
+            const file = fs.createWriteStream(filePath);
+            for (const row of arr) {
+                file.write(JSON.stringify(row) + '\n');
+            }
+            file.end();
+            file.on('finish', () => { resolve(true); });
+            file.on('error', reject);
+        });
+    }
+
+    _readFromFile(filePath) {
+        let result = [];
+        let file = fs.readFileSync(filePath, 'utf-8');
+        let lines = file.split('\n');
+        lines.pop(); // Remove last \n
+
+        for (let line of lines) {
+            result.push(JSON.parse(line));
+        }
+        return result;
     }
 
 }

--- a/submitter/src/services/rsk/RskMMR.js
+++ b/submitter/src/services/rsk/RskMMR.js
@@ -1,27 +1,129 @@
 const Web3 = require('web3');
-
+const fs = require('fs');
+const MMRTree = require('../../lib/mmr/MMRTree');
 const abiMMR = require('../../abis/MMR.json');
 const TransactionSender = require('../../lib/TransactionSender.js');
+const { memoryUsage } = require('../../lib/utils');
+
+const initialSeries = 50;
 
 module.exports = class RskMMR {
     constructor(config, logger) {
         this.config = config;
         this.logger = logger;
+
+        this.rskWeb3 = new Web3(this.config.rsk.host);
+        this.mmrTree = this._restoreMMRTree();
+        this.rskMMRPath = `${config.rskMMRStoragePath || __dirname}/RskMMR.json`;
+        this.requiredConfirmations = config.mmrBlockConfirmations || 10;
     }
 
     async run() {
         try {
-            let rskWeb3 = new Web3(this.config.rsk.host);
-            let transactionSender = new TransactionSender(rskWeb3, this.logger);
+            let transactionSender = new TransactionSender(this.rskWeb3, this.logger);
             let mmrAddress = this.config.rsk.mmr;
-            let mmrContract = new rskWeb3.eth.Contract(abiMMR, mmrAddress);
+            let mmrContract = new this.rskWeb3.eth.Contract(abiMMR, mmrAddress);
             await mmrContract.methods.calculate().call(); //Dry run
             let data = mmrContract.methods.calculate().encodeABI();
             await transactionSender.sendTransaction(mmrAddress, data, 0, this.config.rsk.privateKey);
+            await this._updateMRRTree();
             return true;
         } catch(err) {
             this.logger.error('Exception calling MMR.calculate()', err);
             process.exit();
+        }
+    }
+
+    _restoreMMRTree() {
+        try {
+            let mmrTree = new MMRTree();
+
+            if (fs.existsSync(this.rskMMRPath)) {
+                let serialized = fs.readFileSync(this.rskMMRPath);
+                mmrTree.deserialize(JSON.parse(serialized));
+
+                this.logger.debug('MMRTree restored');
+            }
+
+            return mmrTree;
+        } catch (err) {
+            this.logger.error('Error retrieving mmr backup file', err);
+        }
+    }
+
+    async _updateMRRTree() {
+        try {
+            let lastMRRBlock = this._getLastMMRBlock();
+            let lastBlock = await this.rskWeb3.eth.getBlockNumber();
+            let blockAcceptance = lastBlock - this.requiredConfirmations;
+
+            let series = initialSeries;
+
+            this.logger.debug(`Getting blocks from ${lastMRRBlock} to ${blockAcceptance}`);
+            console.time('MMR Sync');
+
+            while (lastMRRBlock < blockAcceptance) {
+                if (lastMRRBlock + series > blockAcceptance) {
+                    series = blockAcceptance  - lastMRRBlock;
+                }
+
+                let calls = [];
+                for (let i = 0; i < series; i++) {
+                    calls.push({ fn: this.rskWeb3.eth.getBlock, blockNumber: lastMRRBlock + i });
+                }
+
+                let blockSeries = await this._makeBatchRequest(calls);
+
+                blockSeries.forEach(async block => {
+                    await this.mmrTree.appendBlock(block);
+                });
+
+                lastMRRBlock = lastMRRBlock + series;
+            }
+
+            console.timeEnd('MMR Sync');
+            this.logger.debug(`Current allocated memory: ${memoryUsage()} MB`);
+
+        } catch (err) {
+            this.logger.error('Exception updating MRRTree ', err);
+        }
+    }
+
+    _makeBatchRequest(calls) {
+        let batch = new this.rskWeb3.eth.BatchRequest();
+
+        let promises = calls.map(call => {
+            return new Promise((res, rej) => {
+                let req = call.fn.request(call.blockNumber, (err, data) => {
+                    if (err) {
+                        rej(err);
+                    } else {
+                        res(data);
+                    }
+                });
+                batch.add(req)
+            })
+        })
+        batch.execute();
+
+        return Promise.all(promises);
+    }
+
+    _getLastMMRBlock() {
+        let root = this.mmrTree.getRoot();
+        if (root) {
+            return root.end_height;
+        }
+        return 0;
+    }
+
+    exitHandler() {
+        try {
+            let serializedTree = this.mmrTree.serialize();
+            fs.writeFileSync(this.rskMMRPath, JSON.stringify(serializedTree));
+            this.logger.debug('MMRTree saved');
+        } catch (err) {
+            this.logger.error('Failed to save mmr tree', err);
         }
     }
 

--- a/submitter/src/services/rsk/RskMMR.js
+++ b/submitter/src/services/rsk/RskMMR.js
@@ -53,22 +53,22 @@ module.exports = class RskMMR {
 
     async _updateMRRTree() {
         try {
-            let lastMRRBlock = this._getLastMMRBlock();
+            let nextMRRBlock = this._getNextMMRBlock();
             let lastBlock = await this.rskWeb3.eth.getBlockNumber();
             let blockAcceptance = lastBlock - this.requiredConfirmations;
 
             let series = initialSeries;
 
-            this.logger.debug(`Available blocks from ${lastMRRBlock} to ${blockAcceptance}`);
+            this.logger.debug(`Available blocks from ${nextMRRBlock} to ${blockAcceptance}`);
 
-            while (lastMRRBlock < blockAcceptance) {
-                if (lastMRRBlock + series > blockAcceptance) {
-                    series = blockAcceptance  - lastMRRBlock;
+            while (nextMRRBlock < blockAcceptance) {
+                if (nextMRRBlock + series > blockAcceptance) {
+                    series = blockAcceptance  - nextMRRBlock;
                 }
 
                 let calls = [];
                 for (let i = 0; i < series; i++) {
-                    calls.push({ fn: this.rskWeb3.eth.getBlock, blockNumber: lastMRRBlock + i });
+                    calls.push({ fn: this.rskWeb3.eth.getBlock, blockNumber: nextMRRBlock + i });
                 }
 
                 let blockSeries = await this._makeBatchRequest(calls);
@@ -77,9 +77,9 @@ module.exports = class RskMMR {
                     await this.mmrTree.appendBlock(block);
                 });
 
-                this.logger.debug(`Added blocks from ${lastMRRBlock} to ${lastMRRBlock + series}`);
+                this.logger.debug(`Added blocks from ${nextMRRBlock} to ${nextMRRBlock + series}`);
 
-                lastMRRBlock = lastMRRBlock + series;
+                nextMRRBlock = nextMRRBlock + series;
             }
 
         } catch (err) {
@@ -107,10 +107,10 @@ module.exports = class RskMMR {
         return Promise.all(promises);
     }
 
-    _getLastMMRBlock() {
+    _getNextMMRBlock() {
         let root = this.mmrTree.getRoot();
         if (root) {
-            return root.end_height;
+            return root.end_height + 1;
         }
         return 0;
     }

--- a/submitter/test/mmr/mmr.test.js
+++ b/submitter/test/mmr/mmr.test.js
@@ -235,22 +235,12 @@ describe('MMR tests', () => {
             //    /   \
             //   1     2
             //
-            // Serializes to: [3, 1, -1, -1, 2, -1, -1]
+            // Serializes to: [1, 2]
             //
 
-            expect(serialized.length).to.eq(7);
-            expect(serialized[0].hash).to.exist;
-            expect(serialized[0].left.hash).to.equals(node0.hash);
-            expect(serialized[0].right.hash).to.equals(node1.hash);
-            expect(serialized[1].hash).to.eq(node0.hash);
-            expect(serialized[1].left).to.be.null;
-            expect(serialized[1].right).to.be.null;
-            expect(serialized[2]).to.eq(-1);
-            expect(serialized[3]).to.eq(-1);
-            expect(serialized[4].left).to.be.null;
-            expect(serialized[4].right).to.be.null;
-            expect(serialized[5]).to.eq(-1);
-            expect(serialized[6]).to.eq(-1);
+            expect(serialized.length).to.eq(2);
+            expect(serialized[0].hash).to.eq(node0.hash);
+            expect(serialized[1].hash).to.eq(node1.hash);
         });
 
         it('Deserializes from list to tree', () => {
@@ -263,6 +253,7 @@ describe('MMR tests', () => {
 
             let serialized = mmr.serialize();
 
+            mmr = new MMRTree();
             mmr.deserialize(serialized);
 
             let mmrRoot = mmr.getRoot();

--- a/submitter/test/rsk/rskMMR.test.js
+++ b/submitter/test/rsk/rskMMR.test.js
@@ -1,0 +1,107 @@
+const expect = require('chai').expect;
+const Web3 = require('web3');
+const fs = require('fs');
+const RskMMR = require('../../src/services/rsk/RskMMR');
+const MMRNode = require('../../src/lib/mmr/MMRNode.js');
+const config = require('../../config');
+
+const rskWeb3 = new Web3(config.rsk.host);
+const requiredConfirmations = config.mmrBlockConfirmations || 10;
+const rskMMRStoragePath = `${__dirname}`;
+let testConfig = { ...config, rskMMRStoragePath };
+
+const block0 = {
+    number: 131925,
+    hash: '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
+    difficulty: '423484912534602',
+    totalDifficulty: '11761856316565426264',
+    timestamp: 1566252081
+};
+const block1 = {
+    number: 131926,
+    hash: '0xa636cbd79d6c94cd0c68ad90b6a90df0dbe610f0ad1fe643c8f07a12f332137d',
+    difficulty: '423484912534603',
+    totalDifficulty: '11761856316565426265',
+    timestamp: 1566252082
+};
+
+describe('RskMMR tests', () => {
+
+    it('Creates the mmr tree from rsk blocks', async () => {
+        let rskMMR = new RskMMR(testConfig, console);
+        let lastBlock = await rskWeb3.eth.getBlockNumber();
+
+        await rskMMR._updateMRRTree();
+
+        expect(rskMMR.mmrTree).to.exist;
+
+        let mmrRoot = rskMMR.mmrTree.getRoot();
+        expect(mmrRoot).to.exist;
+        expect(mmrRoot.end_height).to.be.greaterThan(0);
+        expect(mmrRoot.end_height).to.be.lte(lastBlock - requiredConfirmations);
+    });
+
+    it('Returns a list of promises from batch', async () => {
+        let rskMMR = new RskMMR(testConfig, console);
+        let calls = [];
+        for (let i = 0; i < 2; i++) {
+            calls.push({ fn: rskWeb3.eth.getBlock, blockNumber: i });
+        }
+
+        let batchResult = await rskMMR._makeBatchRequest(calls);
+
+        expect(batchResult.length).to.eq(2);
+        batchResult.forEach((b, i) => {
+            expect(b.number).to.eq(i);
+        })
+    });
+
+    it('Gets the last block from mmr tree', () => {
+        let rskMMR = new RskMMR(testConfig, console);
+        let empty = rskMMR._getLastMMRBlock();
+
+        expect(empty).to.eq(0);
+
+        let node0 = MMRNode.fromBlock(block0);
+        rskMMR.mmrTree._appendLeaf(node0);
+
+        let node1 = MMRNode.fromBlock(block1);
+        rskMMR.mmrTree._appendLeaf(node1);
+
+        let last = rskMMR._getLastMMRBlock();
+        expect(last).to.eq(block1.number);
+    });
+
+    it('Saves the current mmr tree', async () => {
+        let rskMMR = new RskMMR(testConfig, console);
+        let path = `${rskMMRStoragePath}/RskMMR.json`;
+
+        let node0 = MMRNode.fromBlock(block0);
+        rskMMR.mmrTree._appendLeaf(node0);
+
+        let node1 = MMRNode.fromBlock(block1);
+        rskMMR.mmrTree._appendLeaf(node1);
+
+        rskMMR.exitHandler();
+
+        expect(fs.existsSync(path)).to.eq(true);
+    });
+
+    it('Restores the stored mmr tree', () => {
+        let rskMMR = new RskMMR(testConfig, console);
+
+        let node0 = MMRNode.fromBlock(block0);
+        rskMMR.mmrTree._appendLeaf(node0);
+
+        let node1 = MMRNode.fromBlock(block1);
+        rskMMR.mmrTree._appendLeaf(node1);
+
+        rskMMR.exitHandler();
+        rskMMR._restoreMMRTree();
+
+        let mmrRoot = rskMMR.mmrTree.getRoot();
+        expect(mmrRoot.hash).to.exist;
+        expect(mmrRoot.left).to.equals(node0);
+        expect(mmrRoot.right).to.equals(node1);
+    });
+});

--- a/submitter/test/services/rsk/rskMMR.test.js
+++ b/submitter/test/services/rsk/rskMMR.test.js
@@ -1,9 +1,10 @@
 const expect = require('chai').expect;
 const Web3 = require('web3');
 const fs = require('fs');
-const RskMMR = require('../../src/services/rsk/RskMMR');
-const MMRNode = require('../../src/lib/mmr/MMRNode.js');
-const config = require('../../config');
+const RskMMR = require('../../../src/services/rsk/RskMMR');
+const MMRNode = require('../../../src/lib/mmr/MMRNode.js');
+const config = require('../../../config');
+const testHelper = require('../../testHelper');
 
 const rskWeb3 = new Web3(config.rsk.host);
 const requiredConfirmations = config.mmrBlockConfirmations || 10;
@@ -46,6 +47,7 @@ describe('RskMMR tests', () => {
     it('Returns a list of promises from batch', async () => {
         let rskMMR = new RskMMR(testConfig, console);
         let calls = [];
+        testHelper.advanceBlock(rskWeb3);
         for (let i = 0; i < 2; i++) {
             calls.push({ fn: rskWeb3.eth.getBlock, blockNumber: i });
         }
@@ -59,8 +61,8 @@ describe('RskMMR tests', () => {
     });
 
     it('Gets the last block from mmr tree', () => {
-        let rskMMR = new RskMMR({ ...testConfig, rskMMRStoragePath: '' }, console);
-        let empty = rskMMR._getLastMMRBlock();
+        let rskMMR = new RskMMR({ ...testConfig, rskMMRStoragePath: ' ' }, console);
+        let empty = rskMMR._getNextMMRBlock();
 
         expect(empty).to.eq(0);
 
@@ -70,8 +72,8 @@ describe('RskMMR tests', () => {
         let node1 = MMRNode.fromBlock(block1);
         rskMMR.mmrTree._appendLeaf(node1);
 
-        let last = rskMMR._getLastMMRBlock();
-        expect(last).to.eq(block1.number);
+        let last = rskMMR._getNextMMRBlock();
+        expect(last).to.eq(block1.number + 1);
     });
 
     it('Saves the current mmr tree', async () => {

--- a/submitter/test/testHelper.js
+++ b/submitter/test/testHelper.js
@@ -1,0 +1,42 @@
+
+advanceTimeAndBlock = async (web3, time) => {
+    await advanceTime(web3,time);
+    await advanceBlock(web3);
+
+    return Promise.resolve(web3.eth.getBlock('latest'));
+}
+
+advanceTime = (web3, time) => {
+    return new Promise((resolve, reject) => {
+        web3.currentProvider.sendAsync({
+            jsonrpc: "2.0",
+            method: "evm_increaseTime",
+            params: [time],
+            id: new Date().getTime()
+        }, (err, result) => {
+            if (err) { return reject(err); }
+            return resolve(result);
+        });
+    });
+}
+
+advanceBlock = (web3) => {
+    return new Promise((resolve, reject) => {
+        web3.currentProvider.sendAsync({
+            jsonrpc: "2.0",
+            method: "evm_mine",
+            id: new Date().getTime()
+        }, (err, result) => {
+            if (err) { return reject(err); }
+            const newBlockHash = web3.eth.getBlock('latest').hash;
+
+            return resolve(newBlockHash)
+        });
+    });
+}
+
+module.exports = {
+    advanceTime,
+    advanceBlock,
+    advanceTimeAndBlock
+}


### PR DESCRIPTION
- Added methods to update mmr tree from rsk blocks
- Backup and restore progress from file
- Serialize/deserialize tree
- Test cases added

Some stats on testnet:
- Total blocks processed on first run: 215285
- Time to sync on first run (aprox): 6 minutes
- Backup file size: 66MB
- Max memory peak (aprox): 380 MB
