### PR TITLE
Use string for symbolPrefix

### DIFF
--- a/bridge/contracts/Bridge_v0.sol
+++ b/bridge/contracts/Bridge_v0.sol
@@ -19,7 +19,7 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
     using SafeMath for uint256;
     using SafeERC20 for ERC20Detailed;
 
-    uint8 public symbolPrefix;
+    string public symbolPrefix;
     uint256 public crossingPayment;
 
     mapping (address => SideToken) public mappedTokens; // OirignalToken => SideToken
@@ -35,9 +35,9 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
     event AcceptedCrossTransfer(address indexed _tokenAddress, address indexed _to, uint256 _amount);
     event CrossingPaymentChanged(uint256 _amount);
 
-    function initialize(address _manager, address _allowTokens, address _sideTokenFactory, uint8 _symbolPrefix)
+    function initialize(address _manager, address _allowTokens, address _sideTokenFactory, string memory _symbolPrefix)
     public initializer {
-        require(_symbolPrefix != 0, "Empty symbol prefix");
+        require(bytes(_symbolPrefix).length > 0, "Empty symbol prefix");
         require(_allowTokens != address(0), "Missing AllowTokens contract address");
         require(_manager != address(0), "Manager is empty");
         UpgradableOwnable.initialize(_manager);

--- a/bridge/contracts/test/Bridge_upgrade_test.sol
+++ b/bridge/contracts/test/Bridge_upgrade_test.sol
@@ -19,7 +19,7 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
     using SafeMath for uint256;
     using SafeERC20 for ERC20Detailed;
 
-    uint8 public symbolPrefix;
+    string public symbolPrefix;
     uint256 public crossingPayment;
 
     mapping (address => SideToken) public mappedTokens; // OirignalToken => SideToken
@@ -35,8 +35,8 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
     event AcceptedCrossTransfer(address indexed _tokenAddress, address indexed _to, uint256 _amount);
     event CrossingPaymentChanged(uint256 _amount, string test);
 
-    function initialize(address _manager, address _allowTokens, address _sideTokenFactory, uint8 _symbolPrefix) public initializer {
-        require(_symbolPrefix != 0, "Empty symbol prefix");
+    function initialize(address _manager, address _allowTokens, address _sideTokenFactory, string memory _symbolPrefix) public initializer {
+        require(bytes(_symbolPrefix).length > 0, "Empty symbol prefix");
         require(_allowTokens != address(0), "Missing AllowTokens contract address");
         require(_manager != address(0), "Manager is empty");
         UpgradableOwnable.initialize(_manager);

--- a/bridge/migrations/3_deploy_bridge_v0.js
+++ b/bridge/migrations/3_deploy_bridge_v0.js
@@ -22,7 +22,7 @@ async function ozDeploy(options, name, alias, initArgs, from) {
 module.exports = function(deployer, networkName, accounts) {
     let symbol = 'e';
 
-    if(networkName == 'regtest' || networkName == 'testnet')
+    if(networkName == 'regtest' || networkName == 'rsktestnet' || networkName == 'rskmainnet')
         symbol = 'r';
 
     deployer.then(async () => {
@@ -30,7 +30,7 @@ module.exports = function(deployer, networkName, accounts) {
         const allowTokens = await AllowTokens.deployed();
         const sideTokenFactory = await SideTokenFactory.deployed();
         const { network, txParams } = await ConfigManager.initNetworkConfiguration({ network: networkName, from: accounts[0] });
-        let initArgs = [ multiSig.address, allowTokens.address, sideTokenFactory.address, symbol.charCodeAt() ];
+        let initArgs = [ multiSig.address, allowTokens.address, sideTokenFactory.address, symbol ];
 
         await ozDeploy({ network, txParams }, 'Bridge_v0', 'Bridge', initArgs, accounts[0]);
       });

--- a/bridge/test/Bridge_upgrade_test.js
+++ b/bridge/test/Bridge_upgrade_test.js
@@ -47,7 +47,7 @@ contract('Bridge_upgrade_test', async (accounts) => {
 
         it('should initialize it', async () => {
             const proxy = await this.project.createProxy(Bridge_v0,
-                { initMethod: 'initialize', initArgs: [managerAddress, this.allowTokens.address, this.sideTokenFactory.address, 'r'.charCodeAt()] });
+                { initMethod: 'initialize', initArgs: [managerAddress, this.allowTokens.address, this.sideTokenFactory.address, 'r'] });
 
             result = await proxy.methods.owner().call();
             assert.equal(result,  managerAddress);
@@ -56,13 +56,13 @@ contract('Bridge_upgrade_test', async (accounts) => {
             result = await proxy.methods.sideTokenFactory().call();
             assert.equal(result,  this.sideTokenFactory.address);
             result = await proxy.methods.symbolPrefix().call();
-            assert.equal(result,  'r'.charCodeAt());
+            assert.equal(result,  'r');
         });
 
         describe('initialized', async () => {
             beforeEach(async() => {
                 this.proxy = await this.project.createProxy(Bridge_v0, 
-                    { initMethod: 'initialize', initArgs: [managerAddress, this.allowTokens.address, this.sideTokenFactory.address, 'r'.charCodeAt()] });
+                    { initMethod: 'initialize', initArgs: [managerAddress, this.allowTokens.address, this.sideTokenFactory.address, 'r'] });
             });
 
             it('should accept send Transaction', async () => {

--- a/bridge/test/Bridge_v0_test.js
+++ b/bridge/test/Bridge_v0_test.js
@@ -20,7 +20,7 @@ contract('Bridge_v0', async function (accounts) {
         this.allowTokens = await AllowTokens.new(bridgeManager);
         this.sideTokenFactory = await SideTokenFactory.new();
         this.bridge = await Bridge.new();
-        await this.bridge.methods['initialize(address,address,address,uint8)'](bridgeManager, this.allowTokens.address, this.sideTokenFactory.address, 'e'.charCodeAt(), { from: bridgeOwner });
+        await this.bridge.methods['initialize(address,address,address,string)'](bridgeManager, this.allowTokens.address, this.sideTokenFactory.address, 'e', { from: bridgeOwner });
         await this.sideTokenFactory.transferOwnership(this.bridge.address);
     });
 
@@ -159,7 +159,7 @@ contract('Bridge_v0', async function (accounts) {
             this.mirrorAllowTokens = await AllowTokens.new(bridgeManager);
             this.mirrorSideTokenFactory = await SideTokenFactory.new();
             this.mirrorBridge = await Bridge.new();
-            await this.mirrorBridge.methods['initialize(address,address,address,uint8)'](bridgeManager, this.mirrorAllowTokens.address, this.mirrorSideTokenFactory.address, 'r'.charCodeAt(), { from: bridgeOwner });
+            await this.mirrorBridge.methods['initialize(address,address,address,string)'](bridgeManager, this.mirrorAllowTokens.address, this.mirrorSideTokenFactory.address, 'r', { from: bridgeOwner });
             await this.mirrorSideTokenFactory.transferOwnership(this.mirrorBridge.address);
 
             this.amount = 1000;


### PR DESCRIPTION
As Ethereum has many testnets we may want to use larger prefix to distinguish them