### PR TITLE
Set acceptTransfer to be called only by the federation

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -28,7 +28,7 @@ module.exports = {
       port: 8545,
       network_id: "*" // Match any network id
     },
-    regtest: {
+    rskregtest: {
       host: "127.0.0.1",
       port: 4444,
       network_id: "*" // Match any network id

--- a/bridge/contracts/AllowTokens.sol
+++ b/bridge/contracts/AllowTokens.sol
@@ -17,7 +17,7 @@ contract AllowTokens is Ownable {
     event AllowedTokenValidation(bool _enabled);
     event MaxTokensAllowedChanged(uint256 _maxTokens);
     event MinTokensAllowedChanged(uint256 _minTokens);
-    event DailyLimitChange(uint256 dailyLimit);
+    event DailyLimitChanged(uint256 dailyLimit);
 
     modifier notNull(address _address) {
         require(_address != address(0), "AllowTokens: Address cannot be empty");
@@ -92,7 +92,7 @@ contract AllowTokens is Ownable {
     function changeDailyLimit(uint256 _dailyLimit) public onlyOwner {
         require(_dailyLimit >= maxTokensAllowed, "AllowTokens: Daily Limit should be equal or bigger than Max Tokens");
         dailyLimit = _dailyLimit;
-        emit DailyLimitChange(_dailyLimit);
+        emit DailyLimitChanged(_dailyLimit);
     }
 
     function isValidTokenTransfer(address tokenToUse, uint amount, uint spentToday, bool isSideToken) public view returns (bool) {

--- a/bridge/contracts/IBridge.sol
+++ b/bridge/contracts/IBridge.sol
@@ -13,7 +13,7 @@ interface IBridge {
      * ERC-20 tokens approve and transferFrom pattern
      * See https://eips.ethereum.org/EIPS/eip-20#transferfrom
      */
-    function receiveTokens(address tokenToUse, uint256 amount) external payable;
+    function receiveTokens(address tokenToUse, uint256 amount) external payable returns(bool);
 
     function acceptTransfer(
         address originalTokenAddress,
@@ -35,4 +35,5 @@ interface IBridge {
     event Cross(address indexed _tokenAddress, address indexed _to, uint256 _amount, string _symbol, bytes userData);
     event NewSideToken(address indexed _newSideTokenAddress, address indexed _originalTokenAddress, string _newSymbol);
     event AcceptedCrossTransfer(address indexed _tokenAddress, address indexed _to, uint256 _amount);
+    event CrossingPaymentChanged(uint256 _amount);
 }

--- a/bridge/migrations/2_deploy_multisig_and_tokens.js
+++ b/bridge/migrations/2_deploy_multisig_and_tokens.js
@@ -10,7 +10,7 @@ module.exports = function(deployer, networkName, accounts) {
     .then(() => MultiSigWallet.deployed())
     .then(() => deployer.deploy(AllowTokens, MultiSigWallet.address))
     .then(() => {
-        if (networkName == 'development' || networkName == 'regtest') {
+        if (networkName === 'development' || networkName === 'rskregtest') {
             // In a test environment an ERC777 token requires deploying an ERC1820 registry
             // return singletons.ERC1820Registry(accounts[0]); //use a modified version cause RSK returns 0x00 whtn eth_Code is empty
             return ERC1820Registry(accounts[0]); //Remove this and use singletons.ERC1820Registry(accounts[0]); when the nre version of RSKJ is released
@@ -19,9 +19,9 @@ module.exports = function(deployer, networkName, accounts) {
     .then(() => deployer.deploy(SideTokenFactory));
 };
 
+//This will be removed when the new RSKJ version is released
 var resolve = require('resolve');
 const path = require("path");
-//This will be removed when the new RSKJ version is released
 const testHelperNodeMulesPath =  path.dirname(resolve.sync("@openzeppelin/test-helpers"));
 const ether = require(testHelperNodeMulesPath+'/src/ether');
 const send = require(testHelperNodeMulesPath+'/src/send');

--- a/bridge/migrations/3_deploy_bridge_v0.js
+++ b/bridge/migrations/3_deploy_bridge_v0.js
@@ -5,7 +5,7 @@ const SideTokenFactory = artifacts.require('SideTokenFactory');
 const Bridge_v0 = artifacts.require('Bridge_v0');
 
 //example https://github.com/OpenZeppelin/openzeppelin-sdk/tree/master/examples/truffle-migrate/migrations
-async function ozDeploy(options, name, alias, initArgs, from) {
+async function ozDeploy(options, name, alias, initArgs) {
     try {
         // Register v0 of MyContract in the zos project
         scripts.add({ contractsData: [{ name: name, alias: alias }] });
@@ -23,22 +23,23 @@ async function ozDeploy(options, name, alias, initArgs, from) {
 module.exports = function(deployer, networkName, accounts) {
     let symbol = 'e';
 
-    if(networkName == 'regtest' || networkName == 'rsktestnet' || networkName == 'rskmainnet')
+    if(networkName == 'rskregtest' || networkName == 'rsktestnet' || networkName == 'rskmainnet')
         symbol = 'r';
 
     deployer.then(async () => {
         const multiSig = await MultiSigWallet.deployed();
         const allowTokens = await AllowTokens.deployed();
         const sideTokenFactory = await SideTokenFactory.deployed();
+        const federation = await MultiSigWallet.new([accounts[0]], 1);
         const { network, txParams } = await ConfigManager.initNetworkConfiguration({ network: networkName, from: accounts[0] });
-        let initArgs = [ multiSig.address, allowTokens.address, sideTokenFactory.address, symbol ];
+        let initArgs = [ multiSig.address, federation.address, allowTokens.address, sideTokenFactory.address, symbol ];
 
         if (networkName === 'coverage') {
             return deployer
-                .deploy(Bridge_v0, multiSig.address, allowTokens.address, sideTokenFactory.address, symbol)
-                .then(() => Bridge_v0.deployed())
+                .deploy(Bridge_v0, initArgs[0], initArgs[1], initArgs[2], initArgs[3], initArgs[4])
+                .then(() => Bridge_v0.deployed());
         }
 
-        await ozDeploy({ network, txParams }, 'Bridge_v0', 'Bridge', initArgs, accounts[0]);
+        await ozDeploy({ network, txParams }, 'Bridge_v0', 'Bridge', initArgs);
       });
 };

--- a/bridge/migrations/4_create_config_file.js
+++ b/bridge/migrations/4_create_config_file.js
@@ -23,13 +23,15 @@ module.exports = function(deployer, networkName, accounts) {
         }
     }).then(async () => {
         const bridge = await Bridge.deployed();
+        const federation = await bridge.getFederation();
         const multiSig = await MultiSigWallet.deployed();
         const mainToken = await MainToken.deployed();
         const currentProvider = deployer.networks[networkName];
         const config = {
             bridge: bridge.address,
             privateKey: "",
-            multisig: multiSig.address
+            multisig: federation,
+            manager: multiSig.address
         };
         if(shouldDeployToken(networkName)) {
             config.testToken = mainToken.address;

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -17,7 +17,7 @@
     "start": "rm -rf ./build && rm -f ./.openzeppelin/dev-5777.json && truffle migrate --reset",
     "test": "truffle test",
     "coverage": "npx solidity-coverage",
-    "deploy": "rm -f ./.openzeppelin/dev-5777.json && rm -f ./.openzeppelin/dev-33.json truffle migrate --reset --network regtest && truffle migrate --reset --network development"
+    "deploy": "rm -f ./.openzeppelin/dev-5777.json && rm -f ./.openzeppelin/dev-33.json truffle migrate --reset --network rskregtest && truffle migrate --reset --network development"
   },
   "keywords": [
     "rsk",

--- a/bridge/test/AllowTokens_test.js
+++ b/bridge/test/AllowTokens_test.js
@@ -201,7 +201,6 @@ contract('AllowTokens', async function (accounts) {
 
         it('should check min value', async function() {
             let minTokensAllowed = await this.allowTokens.getMinTokensAllowed();
-            console.log("minTokensAllowed", minTokensAllowed.toString());
             let result = await this.allowTokens.isValidTokenTransfer(this.token.address, minTokensAllowed, 0, true);
             assert.equal(result, true);
             result = await this.allowTokens.isValidTokenTransfer(this.token.address, new BN(minTokensAllowed).sub(new BN('1')), 0, true);

--- a/bridge/test/utils.js
+++ b/bridge/test/utils.js
@@ -10,12 +10,12 @@ const promisify = (inner) =>
     })
 );
 
-async function expectThrow (promise) {
-  try {
-    await promise;
-  } catch (error) {
-      return;
-  }
+function expectThrow (promise) {
+  return promise.then( (result) => {
+    assert.equal(result.toString(), "It should have thrown an Error");
+  }, (err) => {
+      return err;
+  });
   
   assert.fail('Expected throw not received');
 }

--- a/bridge/truffle-config.js
+++ b/bridge/truffle-config.js
@@ -24,7 +24,7 @@ module.exports = {
       gasPrice: 20000000000
     },
     //RSK
-    regtest: {
+    rskegtest: {
       host: "127.0.0.1",
       port: 4444,
       network_id: "33",

--- a/federator/.gitignore
+++ b/federator/.gitignore
@@ -2,7 +2,11 @@ config.js
 regtest.json
 development.json
 rinkeby.json
+kovan.json
+ropsten.json
+rskregtest.json
 rsktestnet.json
+rskmainnet.json
 test.json
 federator.log
 db/

--- a/federator/config.sample.js
+++ b/federator/config.sample.js
@@ -1,8 +1,8 @@
 module.exports = {
-    mainchain: require('./regtest.json'),
+    mainchain: require('./rskregtest.json'),
     sidechain: require('./development.json'),
     runEvery: 1, // In minutes,
-    confirmations: 5,
+    confirmations: 120, //if working with ganache set as 0
     privateKey: '',
     storagePath: '/Users/Me/tokenbridge/federator/db'
 }

--- a/federator/src/abis/Bridge_v0.json
+++ b/federator/src/abis/Bridge_v0.json
@@ -78,6 +78,19 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_newFederation",
+        "type": "address"
+      }
+    ],
+    "name": "FederationChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "_newSideTokenAddress",
@@ -203,21 +216,6 @@
   {
     "constant": true,
     "inputs": [],
-    "name": "crossingPayment",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
     "name": "isOwner",
     "outputs": [
       {
@@ -266,6 +264,21 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastDay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "payable": false,
@@ -389,6 +402,21 @@
   {
     "constant": true,
     "inputs": [],
+    "name": "spentToday",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
     "name": "symbolPrefix",
     "outputs": [
       {
@@ -430,7 +458,27 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_manager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_federation",
         "type": "address"
       },
       {
@@ -447,36 +495,6 @@
         "internalType": "string",
         "name": "_symbolPrefix",
         "type": "string"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
       }
     ],
     "name": "initialize",
@@ -566,7 +584,13 @@
       }
     ],
     "name": "receiveTokens",
-    "outputs": [],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "payable": true,
     "stateMutability": "payable",
     "type": "function"
@@ -696,6 +720,66 @@
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getCrossingPayment",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "calcMaxWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newFederation",
+        "type": "address"
+      }
+    ],
+    "name": "changeFederation",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getFederation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
     "type": "function"
   }
 ]


### PR DESCRIPTION
Pass the federation as argument in the Bridge Initialization
The federation is a multisig, we added the creation of the multisig in migrations for simplicity
Rename regtest to rskregtest