### PR TITLE
Remove Bridge as default operator of SideToken

### DIFF
--- a/bridge/contracts/Bridge_v0.sol
+++ b/bridge/contracts/Bridge_v0.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.0;
 // Import base Initializable contract
 import "./zeppelin/upgradable/Initializable.sol";
 // Import interface and library from OpenZeppelin contracts
+import "./zeppelin/upgradable/utils/ReentrancyGuard.sol";
 import "./zeppelin/upgradable/lifecycle/UpgradablePausable.sol";
 import "./zeppelin/upgradable/ownership/UpgradableOwnable.sol";
 
@@ -17,7 +18,7 @@ import "./SideToken.sol";
 import "./SideTokenFactory.sol";
 import "./AllowTokens.sol";
 
-contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausable, UpgradableOwnable {
+contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausable, UpgradableOwnable, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeERC20 for ERC20Detailed;
     using Address for address;
@@ -70,11 +71,11 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
         address tokenAddress,
         address receiver,
         uint256 amount,
-        string memory symbol,
+        string calldata symbol,
         bytes32 blockHash,
         bytes32 transactionHash,
         uint32 logIndex
-    ) public onlyFederation whenNotPaused returns(bool) {
+    ) external onlyFederation whenNotPaused nonReentrant returns(bool) {
         require(!transactionWasProcessed(blockHash, transactionHash, receiver, amount, logIndex), "Transaction already processed");
 
         processTransaction(blockHash, transactionHash, receiver, amount, logIndex);
@@ -97,7 +98,7 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
      * ERC-20 tokens approve and transferFrom pattern
      * See https://eips.ethereum.org/EIPS/eip-20#transferfrom
      */
-    function receiveTokens(address tokenToUse, uint256 amount) public payable whenNotPaused returns(bool) {
+    function receiveTokens(address tokenToUse, uint256 amount) external payable whenNotPaused nonReentrant returns(bool) {
         verifyIsERC20Detailed(tokenToUse);
         address sender = _msgSender();
         require(!sender.isContract(), "Bridge: Contracts can't cross tokens using their addresses as destination");
@@ -114,6 +115,7 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
      * See https://github.com/ethereum/EIPs/issues/223 for details
      */
     function tokenFallback(address from, uint amount, bytes memory userData) public whenNotPaused returns (bool) {
+        require(crossingPayment == 0, "Bridge: Needs payment, use receiveTokens instead");
         verifyIsERC20Detailed(_msgSender());
         //This can only be used with trusted contracts
         crossTokens(_msgSender(), from, amount, userData);
@@ -135,6 +137,7 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
         //Hook from ERC777address
         if(operator == address(this)) return; // Avoid loop from bridge calling to ERC77transferFrom
         require(to == address(this), "Bridge: This contract is not the address receiving the tokens");
+        require(crossingPayment == 0, "Bridge: Needs payment, use receiveTokens instead");
         verifyIsERC20Detailed(_msgSender());
         //This can only be used with trusted contracts
         crossTokens(_msgSender(), from, amount, userData);

--- a/bridge/contracts/Bridge_v0.sol
+++ b/bridge/contracts/Bridge_v0.sol
@@ -82,7 +82,7 @@ contract Bridge_v0 is Initializable, IBridge, IERC777Recipient, UpgradablePausab
 
         if (isMappedToken(tokenAddress)) {
             SideToken sideToken = mappedTokens[tokenAddress];
-            sideToken.operatorMint(receiver, amount, "", "");
+            sideToken.mint(receiver, amount, "", "");
         }
         else {
             require(knownTokens[tokenAddress], "Bridge: Token address is not in knownTokens");

--- a/bridge/contracts/SideToken.sol
+++ b/bridge/contracts/SideToken.sol
@@ -3,31 +3,26 @@ pragma solidity ^0.5.0;
 import "./zeppelin/token/ERC777/ERC777.sol";
 
 contract SideToken is ERC777 {
+    address public minter;
 
-    constructor(string memory name, string memory symbol, address[] memory newDefaultOperators)
-    ERC777(name, symbol, newDefaultOperators) public {}
+    constructor(string memory _name, string memory _symbol, address _minter)
+    ERC777(_name, _symbol, new address[](0)) public {
+        minter = _minter;
+    }
 
-    function operatorMint(
+    modifier onlyMinter() {
+        require(_msgSender() == minter, "SideToken: caller is not the minter");
+        _;
+    }
+    function mint(
         address account,
         uint256 amount,
         bytes memory userData,
         bytes memory operatorData
     )
-    public
+    public onlyMinter
     {
-        require(isDefaultOperator(_msgSender()), "Only default Operators can Mint");
         _mint(_msgSender(), account, amount, userData, operatorData);
-    }
-
-    function isDefaultOperator(address anAddress) public view returns(bool _isDefaultOperator) {
-        _isDefaultOperator = false;
-        for (uint i = 0; i < defaultOperators().length; i++) {
-            if(anAddress == defaultOperators()[i]) {
-                _isDefaultOperator = true;
-                break;
-            }
-        }
-        return _isDefaultOperator;
     }
 
 }

--- a/bridge/contracts/SideTokenFactory.sol
+++ b/bridge/contracts/SideTokenFactory.sol
@@ -7,9 +7,7 @@ contract SideTokenFactory is Secondary {
     event createdSideToken(address sideToken, string symbol);
 
     function createSideToken(string calldata name, string calldata symbol) external onlyPrimary returns(SideToken) {
-        address[] memory defaultOperators = new address[](1);
-        defaultOperators[0] = primary();
-        SideToken sideToken = new SideToken(name, symbol, defaultOperators);
+        SideToken sideToken = new SideToken(name, symbol, primary());
         emit createdSideToken(address(sideToken), symbol);
         return sideToken;
     }

--- a/bridge/contracts/test/Bridge_upgrade_test.sol
+++ b/bridge/contracts/test/Bridge_upgrade_test.sol
@@ -79,7 +79,7 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
 
         if (isMappedToken(tokenAddress)) {
             SideToken sideToken = mappedTokens[tokenAddress];
-            sideToken.operatorMint(receiver, amount, "", "");
+            sideToken.mint(receiver, amount, "", "");
         }
         else {
             require(knownTokens[tokenAddress], "Bridge: Token address is not in knownTokens");

--- a/bridge/contracts/test/Bridge_upgrade_test.sol
+++ b/bridge/contracts/test/Bridge_upgrade_test.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.0;
 // Import base Initializable contract
 import "../zeppelin/upgradable/Initializable.sol";
 // Import interface and library from OpenZeppelin contracts
+import "../zeppelin/upgradable/utils/ReentrancyGuard.sol";
 import "../zeppelin/upgradable/lifecycle/UpgradablePausable.sol";
 import "../zeppelin/upgradable/ownership/UpgradableOwnable.sol";
 
@@ -16,7 +17,7 @@ import "../SideToken.sol";
 import "../SideTokenFactory.sol";
 import "../AllowTokens.sol";
 
-contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, UpgradablePausable, UpgradableOwnable {
+contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, UpgradablePausable, UpgradableOwnable, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeERC20 for ERC20Detailed;
     using Address for address;
@@ -67,11 +68,11 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
         address tokenAddress,
         address receiver,
         uint256 amount,
-        string memory symbol,
+        string calldata symbol,
         bytes32 blockHash,
         bytes32 transactionHash,
         uint32 logIndex
-    ) public  onlyFederation whenNotPaused returns(bool) {
+    ) external  onlyFederation whenNotPaused nonReentrant returns(bool) {
         require(!transactionWasProcessed(blockHash, transactionHash, receiver, amount, logIndex), "Transaction already processed");
 
         processToken(tokenAddress, symbol);
@@ -94,13 +95,13 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
      * ERC-20 tokens approve and transferFrom pattern
      * See https://eips.ethereum.org/EIPS/eip-20#transferfrom
      */
-    function receiveTokens(address tokenToUse, uint256 amount) public payable whenNotPaused returns(bool) {
+    function receiveTokens(address tokenToUse, uint256 amount) external payable whenNotPaused nonReentrant returns(bool) {
         verifyIsERC20Detailed(tokenToUse);
         address sender = _msgSender();
         require(!sender.isContract(), "Bridge: Contracts can't cross tokens using their addresses as destination");
+        sendIncentiveToEventsCrossers(msg.value);
         //Transfer the tokens on IERC20, they should be already Approved for the bridge Address to use them
         ERC20Detailed(tokenToUse).safeTransferFrom(_msgSender(), address(this), amount);
-        sendIncentiveToEventsCrossers(msg.value);
         crossTokens(tokenToUse, _msgSender(), amount, "");
         return true;
     }
@@ -110,7 +111,8 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
      * See https://github.com/ethereum/EIPs/issues/677 for details
      * See https://github.com/ethereum/EIPs/issues/223 for details
      */
-    function tokenFallback(address from, uint amount, bytes memory userData) public whenNotPaused returns(bool) {
+    function tokenFallback(address from, uint amount, bytes memory userData) public whenNotPaused returns (bool) {
+        require(crossingPayment == 0, "Bridge: Need payment, use receiveTokens instead");
         verifyIsERC20Detailed(_msgSender());
         //This can only be used with trusted contracts
         crossTokens(_msgSender(), from, amount, userData);
@@ -132,6 +134,7 @@ contract Bridge_upgrade_test is Initializable, IBridge, IERC777Recipient, Upgrad
         //Hook from ERC777address
         if(operator == address(this)) return; // Avoid loop from bridge calling to ERC77transferFrom
         require(to == address(this), "Bridge: This contract is not the address receiving the tokens");
+        require(crossingPayment == 0, "Bridge: Need payment, use receiveTokens instead");
         verifyIsERC20Detailed(_msgSender());
         //This can only be used with trusted contracts
         crossTokens(_msgSender(), from, amount, userData);

--- a/bridge/contracts/zeppelin/upgradable/utils/ReentrancyGuard.sol
+++ b/bridge/contracts/zeppelin/upgradable/utils/ReentrancyGuard.sol
@@ -1,22 +1,18 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.2;
+
+import "../Initializable.sol";
 
 /**
- * @dev Contract module that helps prevent reentrant calls to a function.
- *
- * Inheriting from `ReentrancyGuard` will make the `nonReentrant` modifier
- * available, which can be aplied to functions to make sure there are no nested
- * (reentrant) calls to them.
- *
- * Note that because there is a single `nonReentrant` guard, functions marked as
- * `nonReentrant` may not call one another. This can be worked around by making
- * those functions `private`, and then adding `external` `nonReentrant` entry
- * points to them.
+ * @title Helps contracts guard against reentrancy attacks.
+ * @author Remco Bloemen <remco@2π.com>, Eenae <alexey@mixbytes.io>
+ * @dev If you mark a function `nonReentrant`, you should also
+ * mark it `external`.
  */
-contract ReentrancyGuard {
+contract ReentrancyGuard is Initializable {
     /// @dev counter to allow mutex lock with only one SSTORE operation
     uint256 private _guardCounter;
 
-    constructor () internal {
+    function initialize() public initializer {
         // The counter starts at one to prevent changing it from zero to a non-zero
         // value, which is a more expensive operation.
         _guardCounter = 1;
@@ -33,6 +29,6 @@ contract ReentrancyGuard {
         _guardCounter += 1;
         uint256 localCounter = _guardCounter;
         _;
-        require(localCounter == _guardCounter, "ReentrancyGuard: reentrant call");
+        require(localCounter == _guardCounter);
     }
 }

--- a/bridge/test/Bridge_v0_test.js
+++ b/bridge/test/Bridge_v0_test.js
@@ -116,9 +116,9 @@ contract('Bridge_v0', async function (accounts) {
 
             it('tokensReceived for ERC777', async function () {
                 const amount = web3.utils.toWei('1000');
-                let erc777 = await SideToken.new("ERC777", "777", [tokenOwner], { from: tokenOwner });
+                let erc777 = await SideToken.new("ERC777", "777", tokenOwner, { from: tokenOwner });
                 await this.allowTokens.addAllowedToken(erc777.address, { from: bridgeManager });
-                await erc777.operatorMint(tokenOwner, amount, "0x", "0x", {from: tokenOwner });
+                await erc777.mint(tokenOwner, amount, "0x", "0x", {from: tokenOwner });
                 const originalTokenBalance = await erc777.balanceOf(tokenOwner);
                 let receipt = await erc777.send(this.bridge.address, amount, "0x", { from: tokenOwner });
                 utils.checkRcpt(receipt);

--- a/bridge/test/Bridge_v0_test.js
+++ b/bridge/test/Bridge_v0_test.js
@@ -114,6 +114,19 @@ contract('Bridge_v0', async function (accounts) {
                 assert.equal(isKnownToken, true);
             });
 
+            it("tokenFallback shouldn't work if setted a crossingPayment", async function () {
+                const amount = web3.utils.toWei('1000');
+                const payment = 1000;
+                const originalTokenBalance = await this.token.balanceOf(tokenOwner);
+                await this.bridge.setCrossingPayment(payment, { from: bridgeManager});
+                utils.expectThrow(this.token.transferAndCall(this.bridge.address, amount, "0x", { from: tokenOwner }));
+
+                const tokenBalance = await this.token.balanceOf(tokenOwner);
+                assert.equal(tokenBalance.toString(), originalTokenBalance);
+                const isKnownToken = await this.bridge.knownTokens(this.token.address);
+                assert.equal(isKnownToken, false);
+            });
+
             it('tokensReceived for ERC777', async function () {
                 const amount = web3.utils.toWei('1000');
                 let erc777 = await SideToken.new("ERC777", "777", tokenOwner, { from: tokenOwner });
@@ -131,12 +144,28 @@ contract('Bridge_v0', async function (accounts) {
                 assert.equal(isKnownToken, true);
             });
 
+            it("tokensReceived shouldn't work if setted a crossingPayment", async function () {
+                const amount = web3.utils.toWei('1000');
+                const payment = 1000;
+                await this.bridge.setCrossingPayment(payment, { from: bridgeManager});
+                
+                let erc777 = await SideToken.new("ERC777", "777", tokenOwner, { from: tokenOwner });
+                await this.allowTokens.addAllowedToken(erc777.address, { from: bridgeManager });
+                await erc777.mint(tokenOwner, amount, "0x", "0x", {from: tokenOwner });
+                const originalTokenBalance = await erc777.balanceOf(tokenOwner);
+                await utils.expectThrow(erc777.send(this.bridge.address, amount, "0x", { from: tokenOwner }));
+
+                const tokenBalance = await erc777.balanceOf(tokenOwner);
+                assert.equal(tokenBalance.toString(), originalTokenBalance.toString());
+                const isKnownToken = await this.bridge.knownTokens(erc777.address);
+                assert.equal(isKnownToken, false);
+            });
+
             it('send money to contract should fail', async function () {
                 const payment = 1000;
                 await utils.expectThrow(web3.eth.sendTransaction( { from:tokenOwner,
                     to: this.bridge.address, value: payment } ));
             });
-
 
             it('receiveTokens with payment successful', async function () {
                 const payment = 1000;

--- a/bridge/test/SideTokenFactory_test.js
+++ b/bridge/test/SideTokenFactory_test.js
@@ -51,8 +51,8 @@ contract('SideTokenFactory', async function (accounts) {
         const name = await sideToken.name();
         assert.equal(name, "SIDE");
 
-        let defaultOperators = await sideToken.defaultOperators();
-        assert.equal(defaultOperators[0], tokenCreator);
+        let minter = await sideToken.minter();
+        assert.equal(minter, tokenCreator);
 
         receipt = await this.sideTokenFactory.createSideToken("OTHERSYMBOL", "OTHERSYMBOL");
         utils.checkRcpt(receipt);
@@ -72,8 +72,8 @@ contract('SideTokenFactory', async function (accounts) {
         let sideTokenAddress = receipt.logs[0].args[0];
         let sideToken = await SideToken.at(sideTokenAddress);
 
-        const isDefaultOperator = await sideToken.isDefaultOperator(anAccount);
-        assert.equal(isDefaultOperator, true);
+        const minter = await sideToken.minter();
+        assert.equal(minter, anAccount);
     });
 
 });

--- a/bridge/test/SideToken_test.js
+++ b/bridge/test/SideToken_test.js
@@ -9,7 +9,7 @@ contract('SideToken', async function (accounts) {
     const anotherAccount = accounts[2];
 
     beforeEach(async function () {
-        this.token = await SideToken.new("SIDE", "SIDE", [tokenCreator]);
+        this.token = await SideToken.new("SIDE", "SIDE", tokenCreator);
     });
 
     it('initial state', async function () {
@@ -27,7 +27,7 @@ contract('SideToken', async function (accounts) {
     });
 
     it('mint', async function () {
-        await this.token.operatorMint(anAccount, 1000, '0x', '0x', { from: tokenCreator });
+        await this.token.mint(anAccount, 1000, '0x', '0x', { from: tokenCreator });
 
         const creatorBalance = await this.token.balanceOf(tokenCreator);
         assert.equal(creatorBalance, 0);
@@ -43,7 +43,7 @@ contract('SideToken', async function (accounts) {
     });
 
     it('mint only default operators', async function () {
-        expectThrow(this.token.operatorMint(anAccount, 1000, '0x', '0x', { from: anAccount }));
+        expectThrow(this.token.mint(anAccount, 1000, '0x', '0x', { from: anAccount }));
 
         const creatorBalance = await this.token.balanceOf(tokenCreator);
         assert.equal(creatorBalance, 0);
@@ -59,7 +59,7 @@ contract('SideToken', async function (accounts) {
     });
 
     it('transfer account to account', async function () {
-        await this.token.operatorMint(anAccount, 1000, '0x', '0x', { from: tokenCreator });
+        await this.token.mint(anAccount, 1000, '0x', '0x', { from: tokenCreator });
         await this.token.transfer(anotherAccount, 400, { from: anAccount });
 
         const creatorBalance = await this.token.balanceOf(tokenCreator);


### PR DESCRIPTION
Bridge now can only Mint
Add ReantrancyGuard to acceptTransfer and receiveTokens
Now calbacks for tokens can only be used if crossingPayment  is 0 as they are not payable