### PR TITLE
Add detach flag to `docker run` line

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -120,7 +120,7 @@ build() {
 }
 
 run_message() {
-    RUN_MESSAGE="docker run --rm \
+    RUN_MESSAGE="docker run -d --rm \
     --network host \
     -v $DEST_DIR/federator/config:/app/federator/config \
     -v $DEST_DIR/federator/db:/app/federator/db \


### PR DESCRIPTION
Without it, the process keeps in foreground forever, being the only viable options to run it under `tmux` or `screen` or `nohup`. Instead, rely on Docker's first-party support for process supervision.