### PR TITLE
Fix login error

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1055,7 +1055,7 @@
                         $('#logIn').attr('onclick', '');
                         isInstalled()
                         .catch( (err) => {
-                            onMetaMaskConnectionError(err);
+                            onMetaMaskConnectionError(err.message ? err : { message: err });
                         });
                     }
                 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -1055,7 +1055,7 @@
                         $('#logIn').attr('onclick', '');
                         isInstalled()
                         .catch( (err) => {
-                            onMetaMaskConnectionError(err.message ? err : { message: err });
+                            onMetaMaskConnectionError(typeof err === 'string' ? { message: err } : err);
                         });
                     }
                 }


### PR DESCRIPTION
Make rLogin error polymorphic with `Error`

Test case:
1. Open rLogin
2. Click outside rLogin
3. See rLogin error message instead of _undefined_