### PR TITLE
Fix nifty wallet

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -830,7 +830,7 @@
             <!-- Copy to Clipboard https://clipboardjs.com/ -->
             <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha384-8CYhPwYlLELodlcQV713V9ZikA3DlCVaXFDpjHfP8Z36gpddf/Vrt47XmKDsCttu" crossorigin="anonymous"></script>
             <!-- rLogin -->
-            <script src="https://unpkg.com/@rsksmart/rlogin@0.1.0/dist/main.js" integrity="sha384-cYICMPdI8IRLucayN5X65f1l+aGnNpFUK5fyXFj8419Obj6SeIpFw57JF2SqMJFc" crossorigin="anonymous"></script>
+            <script src="https://unpkg.com/@rsksmart/rlogin@0.1.1/dist/main.js" integrity="sha384-BxkfkiqvSWCwmBJpdpHlhY1vJDZj/fYQI76nvqsTCMoYgoJEWGXQW2O/1wqNeudb" crossorigin="anonymous"></script>
             <!-- Wallet Connect -->
             <script src="https://unpkg.com/@walletconnect/web3-provider@1.3.1/dist/umd/index.min.js" integrity="sha384-DOJahViDNA9y40Y+NIb/qcO4Cxfe58MRJvtlIzdHdHRrnnhppgFGnipStRNW2DXG" crossorigin="anonymous"></script>
            <!-- async-await-retry  https://github.com/VoodooTeam/async-await-retry -->


### PR DESCRIPTION
Upgrades rLogin fixing use of `window.ethereum.send`. See https://github.com/rsksmart/rLogin/releases/tag/v0.1.1