### PR TITLE
Fix loading when web3modal is closed

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1301,6 +1301,7 @@
                     }
 
                     const provider = await rLogin.connect()
+                        .catch(() => { throw new Error('Error in login') })
                     window.web3 = new Web3(provider);
                     let accounts = await getAccounts();
                     let chainId = await web3.eth.net.getId();

--- a/ui/index.html
+++ b/ui/index.html
@@ -1301,7 +1301,7 @@
                     }
 
                     const provider = await rLogin.connect()
-                        .catch(() => { throw new Error('Error in login') })
+                        .catch(() => { throw new Error('Login failed. Please try again.') })
                     window.web3 = new Web3(provider);
                     let accounts = await getAccounts();
                     let chainId = await web3.eth.net.getId();


### PR DESCRIPTION
The login loading wheel do not disappeared when closing WalletConnect modal without connecting.

Implementation:
I don't know why re-trowing makes the UI catch the error, but it seems something in `rLogin.connect` or `isInstalled` Promise are not correctly handled. Not sure if it is an rLlogin bug... added https://github.com/rsksmart/rLogin/issues/38 on rLogin now :) thanks!