### PR TITLE
Add integration test step in circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ jobs:
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/mongo:3.4.4
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -i 5777 -l 6700000
+        command: ganache-cli -i 5777 -l 6700000 -k istanbul
+      - image: trufflesuite/ganache-cli
+        command: ganache-cli -i 5776 -p 8546 -k istanbul
     steps:
       - checkout
       # Download and cache dependencies
@@ -19,6 +21,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
       - run: cd bridge && npm ci
+      - run: cd federator && npm ci
       - save_cache:
           paths:
             - bridge/node_modules
@@ -29,12 +32,18 @@ jobs:
             cd bridge
             npm run lint
       - run:
-          name: contracts migrate
+          name: deploy contracts in development and mirror
           command: |
             cd bridge
-            npm run migrate
+            npm run deployLocalIntegrationTest
+      - run:
+          name: contracts integration test
+          command: |
+            cd federator
+            npm run integrationTest
       - run:
           name: contracts test
           command: |
             cd bridge
             npm test
+            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,24 +4,30 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: circleci/node:lts
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
+      # The first ganache-cli container is meant to simulate a main chain, and the second one for a side chain (integration testing only)
       - image: trufflesuite/ganache-cli
+        # The gas limit is 6700000 to avoid trying to deploy a contract larger than expected
         command: ganache-cli -i 5777 -l 6700000 -k istanbul
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -i 5776 -p 8546 -k istanbul
+        command: ganache-cli -i 5776 -p 8546 -l 6700000 -k istanbul
     steps:
       - checkout
       # Download and cache dependencies
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "bridge/package.json" }}
-            # fallback to using the latest cache if no exact match is found
+            # Fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: cd bridge && npm ci
-      - run: cd federator && npm ci
+      - run:
+          name: install bridge dependencies
+          command: |
+            cd bridge
+            npm ci
+      - run:
+          name: install federator dependencies
+          command: |
+            cd federator
+            npm ci
       - save_cache:
           paths:
             - bridge/node_modules

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ See the ['federator'](./federator/README.md) for more information about federati
 
 An integration test is prepared for contracts and federators. To properly run integration test, you need check network config in the `truffle-config.js` and `package.json` in `bridge` folder with your test chains' configuration before run `npm run deployIntegrationTest`.
 
+For testing purposes only, an empty `test.local.federator.key` file is available in `federator/config`, which fulfills the role that a `federator.key` file would have in production.
+Also, a `test.local.config.js` configuration is provided in `federator/config` for the same purpose, acting as the `config.js` file would in a productive environment.
+
 1. Check `mnemonic.key` in `bridge`
 1. Check `infura.key` in `bridge`
-1. Check `federator.key` in `federator/config`
-1. Check `config.js` in `federator/config`
 1. Check your `networkName` in `bridge/migrations/4_deploy_erc1820.js` when your test network does not have **ERC1820:Pseudo-introspection Registry Contract** deployed.
 
 Then

--- a/federator/config/test.local.config.js
+++ b/federator/config/test.local.config.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+module.exports = {
+    mainchain: require('./development.json'), //the json containing the smart contract addresses in rsk
+    sidechain: require('./mirrorDevelopment.json'), //the json containing the smart contract addresses in eth
+    runEvery: 2, // In minutes,
+    confirmations: 0, // Number of blocks before processing it, if working with ganache set as 0
+    privateKey: fs.readFileSync(`${__dirname}/test.local.federator.key`, 'utf8'),
+    storagePath: './db',
+    etherscanApiKey: '',
+    runHeartbeatEvery: 1, // In hours
+    endpointsPort: 5000, // Server port
+}

--- a/federator/integrationTest/integrationTest.js
+++ b/federator/integrationTest/integrationTest.js
@@ -3,7 +3,8 @@ const Web3 = require('web3');
 const log4js = require('log4js');
 
 //configurations
-const config = require('../config/config.js');
+// the following file should only be used for integration tests
+const config = require('../config/test.local.config.js');
 const logConfig = require('../config/log-config.json');
 const abiBridge = require('../../abis/Bridge.json');
 const abiMainToken = require('../../abis/ERC677.json');


### PR DESCRIPTION
Add step to run federator integration test in Circle CI pipeline.
Basically runs two local ganache instances, deploys the contracts, runs the test and finally kills off the ganache instances.