### PR TITLE
Add code coverage step to circle CI pipeline, add coveralls dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  coveralls: coveralls/coveralls@1.0.6
 jobs:
   build:
     working_directory: ~/repo
@@ -23,6 +25,13 @@ jobs:
           command: |
             cd bridge
             npm ci
+      - run:
+          name: bridge coverage
+          command: |
+            cd bridge
+            npm run coverage
+      - coveralls/upload:
+          path_to_lcov: "./bridge/coverage"
       - run:
           name: install federator dependencies
           command: |
@@ -57,4 +66,3 @@ jobs:
           command: |
             cd bridge
             npm test
-            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,6 @@ jobs:
             cd bridge
             npm ci
       - run:
-          name: bridge coverage
-          command: |
-            cd bridge
-            npm run coverage
-      - coveralls/upload:
-          path_to_lcov: "./bridge/coverage/lcov.info"
-      - run:
           name: install federator dependencies
           command: |
             cd federator
@@ -62,7 +55,9 @@ jobs:
             cd federator
             npm test
       - run:
-          name: bridge unit tests
+          name: bridge unit tests + coverage
           command: |
             cd bridge
-            npm test
+            npm run coverage
+      - coveralls/upload:
+          path_to_lcov: "./bridge/coverage/lcov.info"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             cd bridge
             npm run coverage
       - coveralls/upload:
-          path_to_lcov: "./bridge/coverage"
+          path_to_lcov: "./bridge/coverage/lcov.info"
       - run:
           name: install federator dependencies
           command: |

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,5 +1,9 @@
 # Token Bridge Contracts
 
+## Contract coverage
+
+[![Coverage Status](https://coveralls.io/repos/github/rsksmart/tokenbridge/badge.svg)](https://coveralls.io/github/rsksmart/tokenbridge)
+
 ## Install dependencies
 Don't use Node 14 as it has issues with truffle, use node 8, 10 or 12.
 Install node https://nodejs.org/es/

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "axios": ">=0.21.1",
+        "coveralls": "^3.1.1",
         "css-what": ">=5.0.1",
         "elliptic": ">=6.5.4",
         "glob-parent": ">=5.1.2",
@@ -15173,7 +15174,30 @@
         "util-deprecate": "^1.0.1"
       },
       "engines": {
+<<<<<<< HEAD
         "node": ">= 6"
+=======
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true,
+      "bin": {
+        "lcov-parse": "bin/cli.js"
+      }
+    },
+    "node_modules/leb128": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.5.tgz",
+      "integrity": "sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==",
+      "optional": true,
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "buffer-pipe": "0.0.3"
+>>>>>>> Add code coverage step to circle CI pipeline, add coveralls orb, update circleci config version
       }
     },
     "node_modules/inquirer": {
@@ -15647,10 +15671,26 @@
         "node": ">=6"
       }
     },
+<<<<<<< HEAD
     "node_modules/web3-core-requestmanager": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.1.tgz",
       "integrity": "sha512-AniBbDmcsm4somBkUQvAk7p3wzKYsea9ZP8oj4S34bYauVW0CFGiOyS9yRNmSwj36NVbwtYL3npVoc4+W8Lusg==",
+=======
+    "node_modules/log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.6"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+>>>>>>> Add code coverage step to circle CI pipeline, add coveralls orb, update circleci config version
       "dependencies": {
         "util": "^0.12.0",
         "web3-core-helpers": "1.5.1",
@@ -32562,6 +32602,19 @@
         "parse-json": "^4.0.0"
       }
     },
+    "coveralls": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
+      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "lcov-parse": "^1.0.0",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.5",
+        "request": "^2.88.2"
+      }
+    },
     "crc-32": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
@@ -37998,6 +38051,12 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true
+    },
     "leb128": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.5.tgz",
@@ -38514,6 +38573,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.zipwith/-/lodash.zipwith-4.2.0.tgz",
       "integrity": "sha1-r6zwP9LzhK8p4mPDxr2juA4/Uf0="
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -248,6 +248,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5071,6 +5072,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
       "integrity": "sha512-UK7fjncAzs59iu/o2kwYtb8jgTtW6B+cNWIiNpAJkfRwqoMk1xD/6i25ktzwe4qO8gQgoR9RxA5ibC23nq8BLg==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "optional": true,
       "dependencies": {
         "cids": "^1.0.0",
@@ -5693,6 +5695,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.1.tgz",
       "integrity": "sha512-FlmPorLEeCEDPu+uIn0Qardgiy5XqVA4IyNTz9wb9c0e2U7BEXdRcIbx64r09o4Abtf+4B7mkTtMbsIXMxZzKw==",
+      "deprecated": "This module is no longer maintained",
       "optional": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1",
@@ -6379,6 +6382,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -6507,6 +6519,7 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
       "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
+      "deprecated": "This module has been superseded by @ipld/dag-pb and multiformats",
       "optional": true,
       "dependencies": {
         "cids": "^1.0.0",
@@ -7171,6 +7184,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "optional": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
       },
@@ -7334,6 +7348,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@nodefactory/filsnap-adapter/-/filsnap-adapter-0.2.2.tgz",
       "integrity": "sha512-nbaYMwVopOXN2bWOdDY3il6gGL9qMuCmMN4WPuoxzJjSnAMJNqEeSe6MNNJ/fYBLipZcJfAtirNXRrFLFN+Tvw==",
+      "deprecated": "Package is deprecated in favour of @chainsafe/filsnap-adapter",
       "optional": true
     },
     "node_modules/debug-fabulous": {
@@ -8044,6 +8059,15 @@
       "dependencies": {
         "readable-stream": "~1.0.15",
         "xtend": "~2.1.1"
+      }
+    },
+    "node_modules/lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true,
+      "bin": {
+        "lcov-parse": "bin/cli.js"
       }
     },
     "node_modules/truffle/node_modules/yargs-unparser/node_modules/locate-path": {
@@ -10518,6 +10542,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
       "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dependencies": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
@@ -13194,6 +13219,25 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/coveralls": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
+      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "lcov-parse": "^1.0.0",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.5",
+        "request": "^2.88.2"
+      },
+      "bin": {
+        "coveralls": "bin/coveralls.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ganache-cli/node_modules/once": {
       "version": "1.4.0",
       "inBundle": true,
@@ -15174,30 +15218,7 @@
         "util-deprecate": "^1.0.1"
       },
       "engines": {
-<<<<<<< HEAD
         "node": ">= 6"
-=======
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true,
-      "bin": {
-        "lcov-parse": "bin/cli.js"
-      }
-    },
-    "node_modules/leb128": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.5.tgz",
-      "integrity": "sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==",
-      "optional": true,
-      "dependencies": {
-        "bn.js": "^5.0.0",
-        "buffer-pipe": "0.0.3"
->>>>>>> Add code coverage step to circle CI pipeline, add coveralls orb, update circleci config version
       }
     },
     "node_modules/inquirer": {
@@ -15486,6 +15507,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
       "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "optional": true,
       "dependencies": {
         "@multiformats/base-x": "^4.0.1",
@@ -15671,26 +15693,10 @@
         "node": ">=6"
       }
     },
-<<<<<<< HEAD
     "node_modules/web3-core-requestmanager": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.1.tgz",
       "integrity": "sha512-AniBbDmcsm4somBkUQvAk7p3wzKYsea9ZP8oj4S34bYauVW0CFGiOyS9yRNmSwj36NVbwtYL3npVoc4+W8Lusg==",
-=======
-    "node_modules/log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.6"
-      }
-    },
-    "node_modules/log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
->>>>>>> Add code coverage step to circle CI pipeline, add coveralls orb, update circleci config version
       "dependencies": {
         "util": "^0.12.0",
         "web3-core-helpers": "1.5.1",
@@ -18904,6 +18910,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
       "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "optional": true,
       "dependencies": {
         "@multiformats/base-x": "^4.0.1"
@@ -19032,6 +19039,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "optional": true,
       "dependencies": {
         "lcid": "^1.0.0"
       },
@@ -19901,6 +19909,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
       "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dependencies": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
@@ -22383,6 +22392,7 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.1.tgz",
       "integrity": "sha512-Bakj/cnxQBdscORyf4LRHxQJQfoaY8KWc7PWROQgX+aw5FCzBt8ga0VM/59K+ABOznsqNvyLR/wz/oYImOpXJw==",
+      "deprecated": "This module has been superseded by @ipld/dag-cbor and multiformats",
       "optional": true,
       "dependencies": {
         "borc": "^2.1.2",
@@ -24707,6 +24717,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
       "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "optional": true,
       "dependencies": {
         "blakejs": "^1.1.0",
@@ -36985,7 +36996,8 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "optional": true
     },
     "io-ts": {
       "version": "1.10.4",
@@ -38047,6 +38059,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "optional": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -40025,6 +40038,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "optional": true,
       "requires": {
         "lcid": "^1.0.0"
       }

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -15,7 +15,7 @@
     "coverage": "npx hardhat coverage",
     "size": "npx hardhat size-contracts",
     "deploy": "npx hardhat deploy --network",
-    "deployIntegrationTest": "npm run delpoy rskregtest && npm run deploy development",
+    "deployIntegrationTest": "npm run deploy rskregtest && npm run deploy development",
     "deployLocalIntegrationTest": "npm run deploy development && npm run deploy mirrorDevelopment"
   },
   "keywords": [

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "axios": ">=0.21.1",
+    "coveralls": "^3.1.1",
     "css-what": ">=5.0.1",
     "elliptic": ">=6.5.4",
     "glob-parent": ">=5.1.2",


### PR DESCRIPTION
- Add coverage step to circleci pipeline (remove Bridge's unit testing phase, since the coverage one already runs those tests)
- Add coveralls' coverage badge to Bridge's README.md
- Fix typo in the Bridge's `deployIntegrationTest` npm script