### PR TITLE
Fix gas estimation harcoding it

### DIFF
--- a/federator/package-lock.json
+++ b/federator/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "federator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "axios": "^0.21.1",
         "ethereumjs-tx": "^1.3.7",

--- a/federator/package.json
+++ b/federator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "federator",
   "private": "true",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "RSK Bridge Federator",
   "keywords": [
     "rsk",

--- a/federator/src/lib/Federator.js
+++ b/federator/src/lib/Federator.js
@@ -232,9 +232,9 @@ module.exports = class Federator {
                 }).call);
                 this.logger.info('get transaction id:', transactionId);
 
-                let wasProcessed = await utils.retry3Times(fedContract.transactionWasProcessed(transactionId).call);
+                const wasProcessed = await utils.retry3Times(fedContract.transactionWasProcessed(transactionId).call);
                 if (!wasProcessed) {
-                    let hasVoted = await fedContract.hasVoted(transactionId).call({ from });
+                    const hasVoted = await fedContract.hasVoted(transactionId).call({ from });
                     if(!hasVoted) {
                         this.logger.info(`Voting tx: ${log.transactionHash} block: ${log.blockHash} originalTokenAddress: ${tokenAddress}`);
                         await this._voteTransaction(

--- a/federator/src/lib/Heartbeat.js
+++ b/federator/src/lib/Heartbeat.js
@@ -209,7 +209,7 @@ module.exports = class Heartbeat {
 
     _saveProgress (path, value) {
         if (value) {
-            fs.writeFileSync(path, value);
+            fs.writeFileSync(path, value.toString());
         }
     }
 

--- a/federator/src/lib/Heartbeat.js
+++ b/federator/src/lib/Heartbeat.js
@@ -150,7 +150,6 @@ module.exports = class Heartbeat {
 
         try {
             for(let log of logs) {
-                this.logger.info('Processing Heartbeat event log:', log);
 
                 const {
                     blockNumber

--- a/federator/src/lib/TransactionSender.js
+++ b/federator/src/lib/TransactionSender.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const axios = require('axios');
 
 const CustomError = require('./CustomError');
+const ESTIMATED_GAS = 250000;
 
 module.exports = class TransactionSender {
     constructor(client, logger, config) {
@@ -40,9 +41,7 @@ module.exports = class TransactionSender {
         // Gas estimation does not work correctly on RSK and after the London harfork, neither is working on Ethereum
         // example https://etherscan.io/tx/0xd30d6cf428606e2ef3667427b9b6baecb2f4c9cbb44a0c82c735a238ec8f72fb
         // To fix it, we decided to use a hardcoded gas estimation
-        const estimatedGas = 250000;
-
-        return estimatedGas;
+        return ESTIMATED_GAS;
     }
 
     async getEthGasPrice() {

--- a/federator/src/lib/TransactionSender.js
+++ b/federator/src/lib/TransactionSender.js
@@ -40,7 +40,7 @@ module.exports = class TransactionSender {
         // Gas estimation does not work correctly on RSK and after the London harfork, neither is working on Ethereum
         // example https://etherscan.io/tx/0xd30d6cf428606e2ef3667427b9b6baecb2f4c9cbb44a0c82c735a238ec8f72fb
         // To fix it, we decided to use a hardcoded gas estimation
-        const estimatedGas = 200000;
+        const estimatedGas = 250000;
 
         return estimatedGas;
     }
@@ -174,9 +174,10 @@ module.exports = class TransactionSender {
         const chainId =  await this.getChainId();
         let txHash;
         let receipt;
+        let rawTx;
         try {
             let from = await this.getAddress(privateKey);
-            let rawTx = await this.createRawTransaction(from, to, data, value);
+            rawTx = await this.createRawTransaction(from, to, data, value);
             if (privateKey && privateKey.length) {
                 let signedTx = this.signRawTransaction(rawTx, privateKey);
                 const serializedTx = ethUtils.bufferToHex(signedTx.serialize());
@@ -211,7 +212,7 @@ module.exports = class TransactionSender {
             return receipt;
 
         } catch(err) {
-            if(throwOnError) 
+            if(throwOnError)
                 throw new CustomError('Error in sendTransaction', err);
 
             if (err.message.indexOf('it might still be mined') > 0) {

--- a/federator/src/lib/TransactionSender.js
+++ b/federator/src/lib/TransactionSender.js
@@ -36,19 +36,11 @@ module.exports = class TransactionSender {
         return this.getEthGasPrice();
     }
 
-    async getGasLimit(rawTx) {
-        const chainId = await this.getChainId();
-        let estimatedGas = await this.client.eth.estimateGas({
-            gasPrice: rawTx.gasPrice,
-            value: rawTx.value,
-            to: rawTx.to,
-            data: rawTx.data,
-            from: rawTx.from
-        });
-
-        if (chainId >= 30 && chainId <= 33) {
-            estimatedGas = 200000;
-        }
+    async getGasLimit() {
+        // Gas estimation does not work correctly on RSK and after the London harfork, neither is working on Ethereum
+        // example https://etherscan.io/tx/0xd30d6cf428606e2ef3667427b9b6baecb2f4c9cbb44a0c82c735a238ec8f72fb
+        // To fix it, we decided to use a hardcoded gas estimation
+        const estimatedGas = 200000;
 
         return estimatedGas;
     }
@@ -124,7 +116,7 @@ module.exports = class TransactionSender {
             r: 0,
             s: 0
         }
-        rawTx.gas = this.numberToHexString(await this.getGasLimit(rawTx));
+        rawTx.gas = this.numberToHexString(await this.getGasLimit());
 
         if(this.debuggingMode) {
             rawTx.gas = this.numberToHexString(100);

--- a/federator/src/lib/utils.js
+++ b/federator/src/lib/utils.js
@@ -133,7 +133,6 @@ function checkHttpsOrLocalhost(url = '') {
     const isHttps = url.startsWith('https://');
     const isLocalhost = url.startsWith('http://127.0.0.1') ||
         url.startsWith('http://172.17.0.1') ||
-        url.startsWith('http://host.docker.internal') ||
         url.startsWith('http://localhost') ||
         url.startsWith('http://0.0.0.0');
 

--- a/federator/src/lib/utils.js
+++ b/federator/src/lib/utils.js
@@ -133,6 +133,7 @@ function checkHttpsOrLocalhost(url = '') {
     const isHttps = url.slice(0,8).toLowerCase() === 'https://';
     const isLocalhost = url.slice(0,16).toLowerCase() === 'http://127.0.0.1' ||
         url.slice(0,17).toLowerCase() === 'http://172.17.0.1' ||
+        url.slice(0,20).toLowerCase() ===  'host.docker.internal' ||
         url.slice(0,16).toLowerCase() === 'http://localhost' ||
         url.slice(0,14).toLowerCase() === 'http://0.0.0.0';
 

--- a/federator/src/lib/utils.js
+++ b/federator/src/lib/utils.js
@@ -130,12 +130,12 @@ function calculatePrefixesSuffixes(nodes) {
 }
 
 function checkHttpsOrLocalhost(url = '') {
-    const isHttps = url.slice(0,8).toLowerCase() === 'https://';
-    const isLocalhost = url.slice(0,16).toLowerCase() === 'http://127.0.0.1' ||
-        url.slice(0,17).toLowerCase() === 'http://172.17.0.1' ||
-        url.slice(0,20).toLowerCase() ===  'host.docker.internal' ||
-        url.slice(0,16).toLowerCase() === 'http://localhost' ||
-        url.slice(0,14).toLowerCase() === 'http://0.0.0.0';
+    const isHttps = url.startsWith('https://');
+    const isLocalhost = url.startsWith('http://127.0.0.1') ||
+        url.startsWith('http://172.17.0.1') ||
+        url.startsWith('http://host.docker.internal') ||
+        url.startsWith('http://localhost') ||
+        url.startsWith('http://0.0.0.0');
 
     return isHttps || isLocalhost;
 }


### PR DESCRIPTION
Gas estimation does not work correctly on RSK and after the London harfork, neither is working on Ethereum
Example https://etherscan.io/tx/0xd30d6cf428606e2ef3667427b9b6baecb2f4c9cbb44a0c82c735a238ec8f72fb
To fix it, we decided to use a hardcoded gas estimation of 250.000

Also Lucas informed me that we got this error
```[2021-08-17T14:44:18.687] [INFO] HEARTBEAT - [event: HeartBeat],[sender: 0x5eb6cECA6BdD82f4a38AAc0b957E6A4B5b1cCEba],[fedRskBlock: 3609052],[fedEthBlock: 13043315],[federatorVersion: 2.0.0],[nodeRskInfo: RskJ/3.0.0/Linux/Java1.8/IRIS-ba01ea2],[nodeEthInfo: Geth/v1.10.6-stable-576681f2/linux-amd64/go1.16.4],[blockNumber: 3609054],[RskBlockGap: 2],[EstEthBlockGap: 1]
[2021-08-17T14:44:18.687] [INFO] HEARTBEAT - Found 9 heartbeatLogs
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (3609055)
    at Object.writeFileSync (node:fs:2136:5)
    at Heartbeat._saveProgress (/app/federator/src/lib/Heartbeat.js:213:16)
    at Heartbeat.readLogs (/app/federator/src/lib/Heartbeat.js:127:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async run (/app/federator/src/main.js:52:9)
    at async Scheduler.poll (/app/federator/src/services/Scheduler.js:24:13)
    at async Scheduler.start (/app/federator/src/services/Scheduler.js:17:9) {
  code: 'ERR_INVALID_ARG_TYPE'
}
[2021-08-17T14:44:18.687] [ERROR] HEARTBEAT - Error: Exception Running Federator
    at Heartbeat.readLogs (/app/federator/src/lib/Heartbeat.js:134:35)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async run (/app/federator/src/main.js:52:9)
    at async Scheduler.poll (/app/federator/src/services/Scheduler.js:24:13)
    at async Scheduler.start (/app/federator/src/services/Scheduler.js:17:9) TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (3609055)
    at Object.writeFileSync (node:fs:2136:5)
    at Heartbeat._saveProgress (/app/federator/src/lib/Heartbeat.js:213:16)
    at Heartbeat.readLogs (/app/federator/src/lib/Heartbeat.js:127:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async run (/app/federator/src/main.js:52:9)
    at async Scheduler.poll (/app/federator/src/services/Scheduler.js:24:13)
    at async Scheduler.start (/app/federator/src/services/Scheduler.js:17:9) {
  code: 'ERR_INVALID_ARG_TYPE'
}```
The error is that writeFileSync does not support passing a number from this size, so we need to convert it to a string
``` fs.writeFileSync(path, value.toString());```
