### PR TITLE
[TBRE-337] Fixed fee NFT

### DIFF
--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -20,7 +20,7 @@ interface INFTBridge {
     address tokenAddress,
     address to,
     uint256 tokenId
-  ) external;
+  ) payable external;
 
   /**
     * Accepts the transaction from the other chain that was voted and sent by the Federation contract

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -14,7 +14,7 @@ interface INFTBridge {
 
   function version() external pure returns (string memory);
 
-  function getFeePercentage() external view returns (uint256);
+  function getFixedFee() external view returns (uint256);
 
   function receiveTokensTo(
     address tokenAddress,
@@ -85,7 +85,7 @@ interface INFTBridge {
     bytes32 _blockHash,
     uint256 _logIndex
   );
-  event FeePercentageChanged(uint256 _amount);
+  event FixedFeeNFTChanged(uint256 _amount);
   event Claimed(
     bytes32 indexed _transactionHash,
     address indexed _originalTokenAddress,

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -20,7 +20,7 @@ interface INFTBridge {
     address tokenAddress,
     address to,
     uint256 tokenId
-  ) payable external;
+  ) external payable;
 
   /**
     * Accepts the transaction from the other chain that was voted and sent by the Federation contract

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -401,8 +401,9 @@ contract NFTBridge is
   ) public payable override {
     address tokenCreator = getTokenCreator(tokenAddress, tokenId);
 
+    address payable sender = _msgSender();
     // Transfer the tokens on IERC20, they should be already Approved for the bridge Address to use them
-    IERC721(tokenAddress).safeTransferFrom(_msgSender(), address(this), tokenId);
+    IERC721(tokenAddress).safeTransferFrom(sender, address(this), tokenId);
 
     crossTokens(tokenAddress, to, tokenCreator, "", tokenId);
 
@@ -411,6 +412,9 @@ contract NFTBridge is
 
       // Send the payment to the MultiSig of the Federation
       federation.transfer(fixedFee);
+      if (msg.value > fixedFee) { // refund of unused value
+        sender.transfer(msg.value - fixedFee);
+      }
     }
   }
 

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -47,7 +47,7 @@ contract NFTBridge is
       IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
 
   address internal federation;
-  uint256 internal feePercentage;
+  uint256 internal fixedFee;
   string public symbolPrefix;
   uint256 internal _deprecatedLastDay;
   uint256 internal _deprecatedSpentToday;
@@ -60,7 +60,6 @@ contract NFTBridge is
   ISideNFTTokenFactory public sideTokenFactory;
   //Bridge_v1 variables
   bool public isUpgrading;
-  uint256 public constant FEE_PERCENTAGE_DIVIDER = 10000; // Percentage with up to 2 decimals
   //Bridge_v3 variables
   bytes32 internal constant ERC_777_INTERFACE = keccak256("ERC777Token");
   IWrapped public wrappedCurrency;
@@ -452,17 +451,13 @@ contract NFTBridge is
     );
   }
 
-  function setFeePercentage(uint256 amount) external onlyOwner {
-    require(
-        amount < (FEE_PERCENTAGE_DIVIDER / 10),
-        "Bridge: bigger than 10%"
-    );
-    feePercentage = amount;
-    emit FeePercentageChanged(feePercentage);
+  function setFixedFee(uint256 amount) external onlyOwner {
+    fixedFee = amount;
+    emit FixedFeeNFTChanged(fixedFee);
   }
 
-  function getFeePercentage() external view override returns (uint256) {
-    return feePercentage;
+  function getFixedFee() external view override returns (uint256) {
+    return fixedFee;
   }
 
   function changeFederation(address newFederation) external onlyOwner {

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -22,6 +22,7 @@ contract("Bridge NFT", async function(accounts) {
   const tokenContractURI = "https://api-mainnet.rarible.com/contractMetadata";
   const sideTokenSymbolPrefix = "e";
   const newSideNFTTokenEventType = "NewSideNFTToken";
+  const defaultTokenId = 9;
 
   before(async function() {
     await utils.saveState();
@@ -81,7 +82,7 @@ contract("Bridge NFT", async function(accounts) {
   const mintAndApprove = async (
     token,
     approveTo,
-    tokenId = 9,
+    tokenId = defaultTokenId,
     owner = tokenOwner
   ) => {
     let receipt = await token.safeMint(owner, tokenId, {
@@ -167,20 +168,19 @@ contract("Bridge NFT", async function(accounts) {
 
     describe("receiveTokensTo", async function() {
       it("receives ERC721 NFT correctly", async function() {
-        const tokenId = 9;
         const tokenURI = "/ipfs/QmYBX4nZfrHMPFUD9CJcq82Pexp8bpgtf89QBwRNtDQihS";
         let totalSupply = 0; // is the amount of nft minted
 
         await mintAndApprove(this.token, this.bridgeNft.address);
         totalSupply++;
 
-        let receipt = await this.token.setTokenURI(tokenId, tokenURI);
+        let receipt = await this.token.setTokenURI(defaultTokenId, tokenURI);
         utils.checkRcpt(receipt);
 
         receipt = await this.bridgeNft.receiveTokensTo(
           this.token.address,
           anAccount,
-          tokenId,
+          defaultTokenId,
           { from: tokenOwner }
         );
         utils.checkRcpt(receipt);
@@ -195,7 +195,7 @@ contract("Bridge NFT", async function(accounts) {
             ev._tokenCreator == tokenOwner &&
             ev._userData == null &&
             ev._amount == totalSupply &&
-            ev._tokenId == tokenId &&
+            ev._tokenId == defaultTokenId &&
             ev._tokenURI == tokenBaseURI + tokenURI
           );
         });
@@ -209,8 +209,7 @@ contract("Bridge NFT", async function(accounts) {
           });
           utils.checkRcpt(receipt);
 
-          const tokenId = 9;
-          await mintAndApprove(this.token, this.bridgeNft.address, tokenId);
+          await mintAndApprove(this.token, this.bridgeNft.address);
 
           const tokenOwnerBalance = await utils.getBalance(tokenOwner);
           const federatorBalance = await utils.getBalance(federation);
@@ -218,7 +217,7 @@ contract("Bridge NFT", async function(accounts) {
           const tx = await this.bridgeNft.receiveTokensTo(
             this.token.address,
             anAccount,
-            tokenId,
+            defaultTokenId,
             {
               from: tokenOwner,
               value: fixedFee,
@@ -251,14 +250,13 @@ contract("Bridge NFT", async function(accounts) {
           });
           utils.checkRcpt(receipt);
 
-          const tokenId = 9;
-          await mintAndApprove(this.token, this.bridgeNft.address, tokenId);
+          await mintAndApprove(this.token, this.bridgeNft.address);
           const federatorBalance = await utils.getBalance(federation);
 
           const tx = await this.bridgeNft.receiveTokensTo(
             this.token.address,
             anAccount,
-            tokenId,
+            defaultTokenId,
             {
               from: tokenOwner
             }
@@ -273,8 +271,7 @@ contract("Bridge NFT", async function(accounts) {
         });
 
         it("Should fail because the sender doesn't have balance", async function() {
-          const tokenId = 9;
-          await mintAndApprove(this.token, this.bridgeNft.address, tokenId);
+          await mintAndApprove(this.token, this.bridgeNft.address);
 
           const fixedFee = await utils.getBalance(tokenOwner);
           let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
@@ -286,7 +283,7 @@ contract("Bridge NFT", async function(accounts) {
             this.bridgeNft.receiveTokensTo(
               this.token.address,
               anAccount,
-              tokenId,
+              defaultTokenId,
               {
                 from: tokenOwner,
                 value: fixedFee,
@@ -297,8 +294,7 @@ contract("Bridge NFT", async function(accounts) {
         });
 
         it("Should fail because the sended value is smaller than fixed fee", async function() {
-          const tokenId = 9;
-          await mintAndApprove(this.token, this.bridgeNft.address, tokenId);
+          await mintAndApprove(this.token, this.bridgeNft.address);
 
           const fixedFee = new BN(15);
           let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
@@ -310,7 +306,7 @@ contract("Bridge NFT", async function(accounts) {
             this.bridgeNft.receiveTokensTo(
               this.token.address,
               anAccount,
-              tokenId,
+              defaultTokenId,
               {
                 from: tokenOwner,
                 value: fixedFee.sub(new BN(1)),

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -211,8 +211,8 @@ contract("Bridge NFT", async function(accounts) {
 
           await mintAndApprove(this.token, this.bridgeNft.address);
 
-          const tokenOwnerBalance = await utils.getBalance(tokenOwner);
-          const federatorBalance = await utils.getBalance(federation);
+          const tokenOwnerBalance = await utils.getEtherBalance(tokenOwner);
+          const federatorBalance = await utils.getEtherBalance(federation);
 
           const tx = await this.bridgeNft.receiveTokensTo(
             this.token.address,
@@ -225,17 +225,17 @@ contract("Bridge NFT", async function(accounts) {
           );
           utils.checkRcpt(tx);
 
-          const currentTokenOwnerBalance = await utils.getBalance(tokenOwner);
+          const currentTokenOwnerBalance = await utils.getEtherBalance(tokenOwner);
           const expectedTokenOwnerBalance = tokenOwnerBalance
             .sub(fixedFee)
-            .sub(await utils.getGasUsed(tx));
+            .sub(await utils.getGasUsedByTx(tx));
 
           assert(
             currentTokenOwnerBalance.eq(expectedTokenOwnerBalance),
             "Token Owner Balance should be balance - (fixedFee + gas Used)"
           );
 
-          const currentFederatorBalance = await utils.getBalance(federation);
+          const currentFederatorBalance = await utils.getEtherBalance(federation);
           const expectedFederatorBalance = federatorBalance.add(fixedFee);
 
           assert(
@@ -251,7 +251,7 @@ contract("Bridge NFT", async function(accounts) {
           utils.checkRcpt(receipt);
 
           await mintAndApprove(this.token, this.bridgeNft.address);
-          const federatorBalance = await utils.getBalance(federation);
+          const federatorBalance = await utils.getEtherBalance(federation);
 
           const tx = await this.bridgeNft.receiveTokensTo(
             this.token.address,
@@ -262,7 +262,7 @@ contract("Bridge NFT", async function(accounts) {
             }
           );
           utils.checkRcpt(tx);
-          const expectedFederatorBalance = await utils.getBalance(federation);
+          const expectedFederatorBalance = await utils.getEtherBalance(federation);
 
           assert(
             federatorBalance.eq(expectedFederatorBalance),
@@ -273,7 +273,7 @@ contract("Bridge NFT", async function(accounts) {
         it("should fail because the sender doesn't have balance", async function() {
           await mintAndApprove(this.token, this.bridgeNft.address);
 
-          const fixedFee = await utils.getBalance(tokenOwner);
+          const fixedFee = await utils.getEtherBalance(tokenOwner);
           let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
             from: bridgeManager,
           });
@@ -293,7 +293,7 @@ contract("Bridge NFT", async function(accounts) {
           );
         });
 
-        it("Should fail because the sended value is smaller than fixed fee", async function() {
+        it("should fail because the sent value is smaller than fixed fee", async function() {
           await mintAndApprove(this.token, this.bridgeNft.address);
 
           const fixedFee = new BN(15);

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -226,7 +226,7 @@ contract("Bridge NFT", async function(accounts) {
           const gasUsed = new BN(tx.receipt.gasUsed);
 
           let actualTokenOwnerBalance = new BN(await web3.eth.getBalance(tokenOwner));
-          let expectedBalance = tokenOwnerBalance.add(new BN(fixedFee)).add(gasUsed);
+          let expectedBalance = tokenOwnerBalance.sub(new BN(fixedFee)).sub(gasUsed);
 
           console.log('fixedFee', fixedFee);
           console.log('gasUsed', gasUsed.toString());

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -167,7 +167,7 @@ contract("Bridge NFT", async function(accounts) {
     });
 
     describe("receiveTokensTo", async function() {
-      it("receives ERC721 NFT correctly", async function() {
+      it("receives ERC721 NFT correctly with token URI", async function() {
         const tokenURI = "/ipfs/QmYBX4nZfrHMPFUD9CJcq82Pexp8bpgtf89QBwRNtDQihS";
         let totalSupply = 0; // is the amount of nft minted
 
@@ -197,6 +197,36 @@ contract("Bridge NFT", async function(accounts) {
             ev._amount == totalSupply &&
             ev._tokenId == defaultTokenId &&
             ev._tokenURI == tokenBaseURI + tokenURI
+          );
+        });
+      });
+
+      it.only("receives ERC721 NFT correctly without Token URI set", async function() {
+        let totalSupply = 0; // is the amount of nft minted
+
+        await mintAndApprove(this.token, this.bridgeNft.address);
+        totalSupply++;
+
+        let receipt = await this.bridgeNft.receiveTokensTo(
+          this.token.address,
+          anAccount,
+          defaultTokenId,
+          { from: tokenOwner }
+        );
+        utils.checkRcpt(receipt);
+
+        truffleAssert.eventEmitted(receipt, "Cross", (ev) => {
+          // console.log(ev);
+
+          return (
+            ev._tokenAddress == this.token.address &&
+            ev._from == tokenOwner &&
+            ev._to == anAccount &&
+            ev._tokenCreator == tokenOwner &&
+            ev._userData == null &&
+            ev._amount == totalSupply &&
+            ev._tokenId == defaultTokenId &&
+            ev._tokenURI == tokenBaseURI + defaultTokenId
           );
         });
       });

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -201,8 +201,8 @@ contract("Bridge NFT", async function(accounts) {
         });
       });
 
-      describe("Fixed Fee", async function() {
-        it("Federator should receive fee", async function() {
+      describe("fixed fee", async function() {
+        it("should send fee to federator correctly", async function() {
           const fixedFee = new BN("15");
           let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
             from: bridgeManager,
@@ -225,26 +225,26 @@ contract("Bridge NFT", async function(accounts) {
           );
           utils.checkRcpt(tx);
 
-          const actualTokenOwnerBalance = await utils.getBalance(tokenOwner);
+          const currentTokenOwnerBalance = await utils.getBalance(tokenOwner);
           const expectedTokenOwnerBalance = tokenOwnerBalance
             .sub(fixedFee)
             .sub(await utils.getGasUsed(tx));
 
           assert(
-            actualTokenOwnerBalance.eq(expectedTokenOwnerBalance),
+            currentTokenOwnerBalance.eq(expectedTokenOwnerBalance),
             "Token Owner Balance should be balance - (fixedFee + gas Used)"
           );
 
-          const actualFederatorBalance = await utils.getBalance(federation);
+          const currentFederatorBalance = await utils.getBalance(federation);
           const expectedFederatorBalance = federatorBalance.add(fixedFee);
 
           assert(
-            actualFederatorBalance.eq(expectedFederatorBalance),
+            currentFederatorBalance.eq(expectedFederatorBalance),
             "Federator Balance should be balance + fixedFee"
           );
         });
 
-        it("Federator balance should remain the same, because fee is zero", async function() {
+        it("should reamin the same balance for the Federator, because the fixed fee is zero", async function() {
           let receipt = await this.bridgeNft.setFixedFee(new BN(0), {
             from: bridgeManager,
           });
@@ -270,7 +270,7 @@ contract("Bridge NFT", async function(accounts) {
           );
         });
 
-        it("Should fail because the sender doesn't have balance", async function() {
+        it("should fail because the sender doesn't have balance", async function() {
           await mintAndApprove(this.token, this.bridgeNft.address);
 
           const fixedFee = await utils.getBalance(tokenOwner);

--- a/bridge/test/utils.js
+++ b/bridge/test/utils.js
@@ -3,12 +3,12 @@ const BN = web3.utils.BN;
 const gasLimit = 6800000;
 
 const saveState = async () =>
-  new Promise(resolve => {
+  new Promise((resolve) => {
     web3.currentProvider.send(
       {
-        jsonrpc: '2.0',
-        method: 'evm_snapshot',
-        id: 0
+        jsonrpc: "2.0",
+        method: "evm_snapshot",
+        id: 0,
       },
       (error, res) => {
         const result = parseInt(res.result, 0);
@@ -19,13 +19,13 @@ const saveState = async () =>
   });
 
 const revertState = async () => {
-  await new Promise(resolve =>
+  await new Promise((resolve) =>
     web3.currentProvider.send(
       {
-        jsonrpc: '2.0',
-        method: 'evm_revert',
+        jsonrpc: "2.0",
+        method: "evm_revert",
         params: lastSnapshot,
-        id: 0
+        id: 0,
       },
       (error, res) => {
         resolve(res.result);
@@ -40,157 +40,169 @@ const revertState = async () => {
 const promisify = (inner) =>
   new Promise((resolve, reject) =>
     inner((err, res) => {
-      if (err) { reject(err) }
+      if (err) {
+        reject(err);
+      }
 
       resolve(res);
     })
-);
+  );
 
-function expectThrow (promise) {
-  return promise.then( (result) => {
-    assert.equal(result.toString(), "It should have thrown an Error");
-  }, (err) => {
-    return err;
-  });
+function expectThrow(promise) {
+  return promise.then(
+    (result) => {
+      assert.equal(result.toString(), "It should have thrown an Error");
+    },
+    (err) => {
+      return err;
+    }
+  );
 }
 
-
 function checkGas(gas) {
-    //process.stdout.write(`\x1b[36m[Gas:${gas}]\x1b[0m`);
-    assert(gas < gasLimit, "Gas used bigger than the maximum in mainnet");
+  //process.stdout.write(`\x1b[36m[Gas:${gas}]\x1b[0m`);
+  assert(gas < gasLimit, "Gas used bigger than the maximum in mainnet");
 }
 
 function checkRcpt(tx) {
-    assert.equal(Number(tx.receipt.status), 1, "Should be a succesful Tx");
-    checkGas(tx.receipt.gasUsed);
-  }
+  assert.equal(Number(tx.receipt.status), 1, "Should be a succesful Tx");
+  checkGas(tx.receipt.gasUsed);
+}
 
-// @param tx is an object returned from the smartcontract tx {
-//  tx: @string,
-//  receipt: {
-//    gasUsed: @number
-//  }
-// }
-// @return BN the gas used multiplied by the gas price
-const getGasUsed = async (tx) => {
+/**
+ * @type {function}
+ * @param {{
+ *  tx: string,
+ *  receipt: {
+ *    gasUsed: number
+ *  }
+ * }} tx - is an object returned from the smartcontract tx
+ * @returns {BN} the gas used multiplied by the gas price
+ */
+const getGasUsedByTx = async (tx) => {
   const gasUsed = new BN(tx.receipt.gasUsed);
 
-  // Obtain gasPrice from the transaction
   const txWithPrice = await web3.eth.getTransaction(tx.tx);
   const gasPrice = new BN(txWithPrice.gasPrice);
 
   return gasUsed.mul(gasPrice);
-}
+};
 
-// @param address string to check the amount of ether
-// @return BN the balance of ether
-const getBalance = async (address) => {
+/**
+ * @type {function}
+ * @param {string} address - addr to check the amount of ether
+ * @returns {BN} - the ether balance of address
+ */
+const getEtherBalance = async (address) => {
   return new BN(await web3.eth.getBalance(address));
-}
+};
 
 const asyncMine = async () => {
-    return new Promise((resolve, reject) => {
-        web3.currentProvider.send({
-            jsonrpc: "2.0",
-            method: "evm_mine",
-            id: new Date().getTime()
-            }, (error, result) => {
-                if (error) {
-                    return reject(error);
-                }
-                return resolve(result);
-            });
-    });
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        id: new Date().getTime(),
+      },
+      (error, result) => {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(result);
+      }
+    );
+  });
 };
 
 let evm_mine = async (iterations) => {
-    for(var i = 0; i < iterations; i++ ) {
-        await asyncMine();
-    };
+  for (var i = 0; i < iterations; i++) {
+    await asyncMine();
+  }
 };
 
 function increaseTimestamp(web3, increase) {
-    return new Promise((resolve, reject) => {
-        web3.currentProvider.send({
-            method: "evm_increaseTime",
-            params: [increase],
-            jsonrpc: "2.0",
-            id: new Date().getTime()
-          }, (error, result) => {
-            if (error) {
-                return reject(error);
-            }
-            return asyncMine().then( ()=> resolve(result));
-          });
-    });
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        method: "evm_increaseTime",
+        params: [increase],
+        jsonrpc: "2.0",
+        id: new Date().getTime(),
+      },
+      (error, result) => {
+        if (error) {
+          return reject(error);
+        }
+        return asyncMine().then(() => resolve(result));
+      }
+    );
+  });
 }
 
 function stripHexPrefix(hexString) {
-    if (hexString.substring(0, 2).toLowerCase() === '0x'){
-        hexString = hexString.substring(2);
-    }
-    return hexString;
+  if (hexString.substring(0, 2).toLowerCase() === "0x") {
+    hexString = hexString.substring(2);
+  }
+  return hexString;
 }
 
 function calculatePrefixesSuffixes(nodes) {
-    const prefixes = [];
-    const suffixes = [];
-    const ns = [];
+  const prefixes = [];
+  const suffixes = [];
+  const ns = [];
 
-    for (let i = 0; i < nodes.length; i++) {
-        nodes[i] = stripHexPrefix(nodes[i]);
-    }
+  for (let i = 0; i < nodes.length; i++) {
+    nodes[i] = stripHexPrefix(nodes[i]);
+  }
 
-    for (let k = 0, l = nodes.length; k < l; k++) {
-        if (k + 1 < l && nodes[k+1].indexOf(nodes[k]) >= 0)
-            continue;
+  for (let k = 0, l = nodes.length; k < l; k++) {
+    if (k + 1 < l && nodes[k + 1].indexOf(nodes[k]) >= 0) continue;
 
-        ns.push(nodes[k]);
-    }
+    ns.push(nodes[k]);
+  }
 
-    let hash = web3.utils.sha3(Buffer.from(ns[0], 'hex'));
+  let hash = web3.utils.sha3(Buffer.from(ns[0], "hex"));
+  hash = stripHexPrefix(hash);
+
+  prefixes.push("0x");
+  suffixes.push("0x");
+
+  for (let k = 1, l = ns.length; k < l; k++) {
+    const p = ns[k].indexOf(hash);
+
+    prefixes.push("0x" + ns[k].substring(0, p));
+    suffixes.push("0x" + ns[k].substring(p + hash.length));
+
+    hash = web3.utils.sha3(Buffer.from(ns[k], "hex"));
     hash = stripHexPrefix(hash);
-
-    prefixes.push('0x');
-    suffixes.push('0x');
-
-    for (let k = 1, l = ns.length; k < l; k++) {
-        const p = ns[k].indexOf(hash);
-
-        prefixes.push('0x' + ns[k].substring(0, p));
-        suffixes.push('0x' + ns[k].substring(p + hash.length));
-
-        hash = web3.utils.sha3(Buffer.from(ns[k], 'hex'));
-        hash = stripHexPrefix(hash);
-    }
-    return { prefixes: prefixes, suffixes: suffixes };
+  }
+  return { prefixes: prefixes, suffixes: suffixes };
 }
 
-function ascii_to_hexa(str)
-{
-    var arr1 = [];
-    for (var n = 0, l = str.length; n < l; n ++) {
-        var hex = Number(str.charCodeAt(n)).toString(16);
-        arr1.push(hex);
-    }
-    return '0x' + arr1.join('');
+function ascii_to_hexa(str) {
+  var arr1 = [];
+  for (var n = 0, l = str.length; n < l; n++) {
+    var hex = Number(str.charCodeAt(n)).toString(16);
+    arr1.push(hex);
+  }
+  return "0x" + arr1.join("");
 }
-
 
 module.exports = {
-    getBalance: getBalance,
-    getGasUsed: getGasUsed,
-    checkGas: checkGas,
-    checkRcpt: checkRcpt,
-    evm_mine: evm_mine,
-    promisify: promisify,
-    expectThrow: expectThrow,
-    calculatePrefixesSuffixes: calculatePrefixesSuffixes,
-    increaseTimestamp: increaseTimestamp,
-    ascii_to_hexa: ascii_to_hexa,
-    NULL_ADDRESS: '0x0000000000000000000000000000000000000000',
-    NULL_HASH: '0x0000000000000000000000000000000000000000000000000000000000000000',
-    saveState : saveState,
-    revertState: revertState,
+  getEtherBalance: getEtherBalance,
+  getGasUsedByTx: getGasUsedByTx,
+  checkGas: checkGas,
+  checkRcpt: checkRcpt,
+  evm_mine: evm_mine,
+  promisify: promisify,
+  expectThrow: expectThrow,
+  calculatePrefixesSuffixes: calculatePrefixesSuffixes,
+  increaseTimestamp: increaseTimestamp,
+  ascii_to_hexa: ascii_to_hexa,
+  NULL_ADDRESS: "0x0000000000000000000000000000000000000000",
+  NULL_HASH:
+    "0x0000000000000000000000000000000000000000000000000000000000000000",
+  saveState: saveState,
+  revertState: revertState,
 };
-

--- a/bridge/test/utils.js
+++ b/bridge/test/utils.js
@@ -1,3 +1,5 @@
+const BN = web3.utils.BN;
+
 const gasLimit = 6800000;
 
 const saveState = async () =>
@@ -62,6 +64,23 @@ function checkRcpt(tx) {
     assert.equal(Number(tx.receipt.status), 1, "Should be a succesful Tx");
     checkGas(tx.receipt.gasUsed);
   }
+
+// @param tx is an object returned from the smartcontract tx {
+//  tx: @string,
+//  receipt: {
+//    gasUsed: @number
+//  }
+// }
+// @return BN the gas used multiplied by the gas price
+const getGasUsed = async (tx) => {
+  const gasUsed = new BN(tx.receipt.gasUsed);
+
+  // Obtain gasPrice from the transaction
+  const txWithPrice = await web3.eth.getTransaction(tx.tx);
+  const gasPrice = new BN(txWithPrice.gasPrice);
+
+  return gasUsed.mul(gasPrice);
+}
 
 const asyncMine = async () => {
     return new Promise((resolve, reject) => {
@@ -153,6 +172,7 @@ function ascii_to_hexa(str)
 
 
 module.exports = {
+    getGasUsed: getGasUsed,
     checkGas: checkGas,
     checkRcpt: checkRcpt,
     evm_mine: evm_mine,

--- a/bridge/test/utils.js
+++ b/bridge/test/utils.js
@@ -82,6 +82,12 @@ const getGasUsed = async (tx) => {
   return gasUsed.mul(gasPrice);
 }
 
+// @param address string to check the amount of ether
+// @return BN the balance of ether
+const getBalance = async (address) => {
+  return new BN(await web3.eth.getBalance(address));
+}
+
 const asyncMine = async () => {
     return new Promise((resolve, reject) => {
         web3.currentProvider.send({
@@ -172,6 +178,7 @@ function ascii_to_hexa(str)
 
 
 module.exports = {
+    getBalance: getBalance,
     getGasUsed: getGasUsed,
     checkGas: checkGas,
     checkRcpt: checkRcpt,


### PR DESCRIPTION
### Feature of charging a fixed fee at each NFT crossed

Add the possibility to set a fixed when crossing new NFT's

### Description

- Set the federation address as `payable`
- Add methods for setting a fixed fee
- Update `receiveTokensTo` to have the possibility of a charge fixed fee and send this fixed value to an federation 

### How to Test

- Run both `ganache-cli`
- Enter into the bridge directory and run the truffle test in the file `nftbridge/NFTBridge_test.js` to test the Charge of a fixed fee 

#### Case 1

1. Go to bridge directory
```shell
$~ cd bridge
```

2. Run the first ganache-cli
```shell
$~ npm run ganache
```

3. Open another shell and run the ganache mirror
```shell
$~ npm run ganache-mirror
```

4. Run the test file that calls `receiveTokensTo - Fee`
```shell
$~ truffle test test/nftbridge/NFTBridge_test.js
```

__Expected Result__
- It should pass the test
![image](https://user-images.githubusercontent.com/17556614/129735956-c61f251c-8537-4187-b9f4-f9502ee0e8ed.png)

### Checklist

#### Bridge Directory `cd bridge`
- [x] Lint is clean `npm run lint`
- [x] Test is passing `npm run test`
- [x] Contracts are compiling `npm run compile`