### PR TITLE
Add NFT Bridge to Federation

### DIFF
--- a/abis/Bridge.json
+++ b/abis/Bridge.json
@@ -346,19 +346,6 @@
         "type": "function"
     },
     {
-        "inputs": [],
-        "name": "DOMAIN_SEPARATOR",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
         "inputs": [
             {
                 "internalType": "address",
@@ -424,6 +411,19 @@
                 "internalType": "bool",
                 "name": "",
                 "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "domainSeparator",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
             }
         ],
         "stateMutability": "view",

--- a/abis/Federation.json
+++ b/abis/Federation.json
@@ -148,7 +148,7 @@
             {
                 "indexed": false,
                 "internalType": "address",
-                "name": "NFTBridge",
+                "name": "bridgeNFT",
                 "type": "address"
             }
         ],
@@ -263,10 +263,10 @@
     },
     {
         "inputs": [],
-        "name": "NFTBridge",
+        "name": "bridge",
         "outputs": [
             {
-                "internalType": "contract INFTBridge",
+                "internalType": "contract IBridge",
                 "name": "",
                 "type": "address"
             }
@@ -276,10 +276,10 @@
     },
     {
         "inputs": [],
-        "name": "bridge",
+        "name": "bridgeNFT",
         "outputs": [
             {
-                "internalType": "contract IBridge",
+                "internalType": "contract INFTBridge",
                 "name": "",
                 "type": "address"
             }
@@ -498,7 +498,7 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_NFTBridge",
+                "name": "_bridgeNFT",
                 "type": "address"
             }
         ],
@@ -526,7 +526,7 @@
             },
             {
                 "internalType": "uint256",
-                "name": "number",
+                "name": "value",
                 "type": "uint256"
             },
             {
@@ -551,13 +551,7 @@
             }
         ],
         "name": "voteTransaction",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
+        "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
     },

--- a/abis/Federation.json
+++ b/abis/Federation.json
@@ -16,19 +16,6 @@
         "anonymous": false,
         "inputs": [
             {
-                "indexed": false,
-                "internalType": "address",
-                "name": "bridgeNFT",
-                "type": "address"
-            }
-        ],
-        "name": "BridgeNFTChanged",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
                 "indexed": true,
                 "internalType": "address",
                 "name": "federator",
@@ -159,6 +146,19 @@
         "anonymous": false,
         "inputs": [
             {
+                "indexed": false,
+                "internalType": "address",
+                "name": "NFTBridge",
+                "type": "address"
+            }
+        ],
+        "name": "NFTBridgeChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
                 "indexed": true,
                 "internalType": "address",
                 "name": "previousOwner",
@@ -263,10 +263,10 @@
     },
     {
         "inputs": [],
-        "name": "bridge",
+        "name": "NFTBridge",
         "outputs": [
             {
-                "internalType": "contract IBridge",
+                "internalType": "contract INFTBridge",
                 "name": "",
                 "type": "address"
             }
@@ -276,10 +276,10 @@
     },
     {
         "inputs": [],
-        "name": "bridgeNFT",
+        "name": "bridge",
         "outputs": [
             {
-                "internalType": "contract INFTBridge",
+                "internalType": "contract IBridge",
                 "name": "",
                 "type": "address"
             }
@@ -498,11 +498,11 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_bridgeNFT",
+                "name": "_NFTBridge",
                 "type": "address"
             }
         ],
-        "name": "setBridgeNFT",
+        "name": "setNFTBridge",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/abis/Federation.json
+++ b/abis/Federation.json
@@ -16,6 +16,19 @@
         "anonymous": false,
         "inputs": [
             {
+                "indexed": false,
+                "internalType": "address",
+                "name": "bridgeNFT",
+                "type": "address"
+            }
+        ],
+        "name": "BridgeNFTChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
                 "indexed": true,
                 "internalType": "address",
                 "name": "federator",
@@ -262,6 +275,19 @@
         "type": "function"
     },
     {
+        "inputs": [],
+        "name": "bridgeNFT",
+        "outputs": [
+            {
+                "internalType": "contract INFTBridge",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [
             {
                 "internalType": "address",
@@ -472,6 +498,19 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "_bridgeNFT",
+                "type": "address"
+            }
+        ],
+        "name": "setBridgeNFT",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
                 "name": "originalTokenAddress",
                 "type": "address"
             },
@@ -487,7 +526,7 @@
             },
             {
                 "internalType": "uint256",
-                "name": "amount",
+                "name": "number",
                 "type": "uint256"
             },
             {
@@ -504,6 +543,11 @@
                 "internalType": "uint32",
                 "name": "logIndex",
                 "type": "uint32"
+            },
+            {
+                "internalType": "enum Federation.TokenType",
+                "name": "tokenType",
+                "type": "uint8"
             }
         ],
         "name": "voteTransaction",

--- a/abis/SideToken.json
+++ b/abis/SideToken.json
@@ -263,19 +263,6 @@
     },
     {
         "inputs": [],
-        "name": "DOMAIN_SEPARATOR",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
         "name": "PERMIT_TYPEHASH",
         "outputs": [
             {
@@ -406,6 +393,19 @@
                 "internalType": "address[]",
                 "name": "",
                 "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "domainSeparator",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
             }
         ],
         "stateMutability": "view",

--- a/bridge/contracts/Federation.sol
+++ b/bridge/contracts/Federation.sol
@@ -241,7 +241,7 @@ contract Federation is Initializable, UpgradableOwnable {
     TokenType tokenType
   ) internal {
     if (tokenType == TokenType.NFT) {
-      require(bridgeNFT != INFTBridge(0), "Federation: Empty NFTBridge");
+      require(address(bridgeNFT) != NULL_ADDRESS, "Federation: Empty NFTBridge");
       bridgeNFT.acceptTransfer(
         originalTokenAddress,
         sender,

--- a/bridge/contracts/Federation.sol
+++ b/bridge/contracts/Federation.sol
@@ -144,7 +144,7 @@ contract Federation is Initializable, UpgradableOwnable {
       emit BridgeNFTChanged(_bridgeNFT);
     }
 
-    function validateTransaction(bytes32 transactionId) internal returns(bool) {
+    function validateTransaction(bytes32 transactionId) internal view returns(bool) {
       uint transactionCount = getTransactionCount(transactionId);
       return transactionCount >= required && transactionCount >= members.length / 2 + 1;
     }
@@ -241,6 +241,7 @@ contract Federation is Initializable, UpgradableOwnable {
     TokenType tokenType
   ) internal {
     if (tokenType == TokenType.NFT) {
+      require(bridgeNFT != INFTBridge(0), "Federation: Empty bridgeNFT");
       bridgeNFT.acceptTransfer(
         originalTokenAddress,
         sender,

--- a/bridge/contracts/Federation.sol
+++ b/bridge/contracts/Federation.sol
@@ -15,10 +15,41 @@ contract Federation is Initializable, UpgradableOwnable {
 
     IBridge public bridge;
     address[] public members;
+
+    /**
+      @notice The minimum amount of votes to approve a transaction
+      @dev It should have more members than the required amount
+     */
     uint public required;
 
+    /**
+      @notice
+     */
     mapping (address => bool) public isMember;
+
+    /**
+      (bytes32) transactionId = keccak256(
+        abi.encodePacked(
+          originalTokenAddress,
+          sender,
+          receiver,
+          amount,
+          blockHash,
+          transactionHash,
+          logIndex
+        )
+      ) => (
+        (address) members => (bool) voted
+      )
+      @notice Votes by members by the transaction ID
+      @dev usually the members should approve the transaction by 50% + 1
+     */
     mapping (bytes32 => mapping (address => bool)) public votes;
+
+    /**
+      (bytes32) transactionId => (bool) voted
+      @notice Check if that transaction was already processed
+     */
     mapping(bytes32 => bool) public processed;
 
     event Executed(

--- a/bridge/contracts/Federation.sol
+++ b/bridge/contracts/Federation.sol
@@ -17,7 +17,7 @@ contract Federation is Initializable, UpgradableOwnable {
     uint constant public MAX_MEMBER_COUNT = 50;
     address constant private NULL_ADDRESS = address(0);
 
-    INFTBridge public NFTBridge;
+    INFTBridge public bridgeNFT;
     IBridge public bridge;
     address[] public members;
 
@@ -73,7 +73,7 @@ contract Federation is Initializable, UpgradableOwnable {
     event MemberRemoval(address indexed member);
     event RequirementChange(uint required);
     event BridgeChanged(address bridge);
-    event NFTBridgeChanged(address NFTBridge);
+    event NFTBridgeChanged(address bridgeNFT);
     event Voted(
         address indexed federator,
         bytes32 indexed transactionHash,
@@ -134,14 +134,14 @@ contract Federation is Initializable, UpgradableOwnable {
         emit BridgeChanged(_bridge);
     }
 
-    function setNFTBridge(address _NFTBridge) external onlyOwner {
-      _setNFTBridge(_NFTBridge);
+    function setNFTBridge(address _bridgeNFT) external onlyOwner {
+      _setNFTBridge(_bridgeNFT);
     }
 
-    function _setNFTBridge(address _NFTBridge) internal {
-      require(_NFTBridge != NULL_ADDRESS, "Federation: Empty NFT bridge");
-      NFTBridge = INFTBridge(_NFTBridge);
-      emit NFTBridgeChanged(_NFTBridge);
+    function _setNFTBridge(address _bridgeNFT) internal {
+      require(_bridgeNFT != NULL_ADDRESS, "Federation: Empty NFT bridge");
+      bridgeNFT = INFTBridge(_bridgeNFT);
+      emit NFTBridgeChanged(_bridgeNFT);
     }
 
     function validateTransaction(bytes32 transactionId) internal view returns(bool) {
@@ -241,8 +241,8 @@ contract Federation is Initializable, UpgradableOwnable {
     TokenType tokenType
   ) internal {
     if (tokenType == TokenType.NFT) {
-      require(NFTBridge != INFTBridge(0), "Federation: Empty NFTBridge");
-      NFTBridge.acceptTransfer(
+      require(bridgeNFT != INFTBridge(0), "Federation: Empty NFTBridge");
+      bridgeNFT.acceptTransfer(
         originalTokenAddress,
         sender,
         receiver,

--- a/bridge/contracts/Federation.sol
+++ b/bridge/contracts/Federation.sol
@@ -17,7 +17,7 @@ contract Federation is Initializable, UpgradableOwnable {
     uint constant public MAX_MEMBER_COUNT = 50;
     address constant private NULL_ADDRESS = address(0);
 
-    INFTBridge public bridgeNFT;
+    INFTBridge public NFTBridge;
     IBridge public bridge;
     address[] public members;
 
@@ -73,7 +73,7 @@ contract Federation is Initializable, UpgradableOwnable {
     event MemberRemoval(address indexed member);
     event RequirementChange(uint required);
     event BridgeChanged(address bridge);
-    event BridgeNFTChanged(address bridgeNFT);
+    event NFTBridgeChanged(address NFTBridge);
     event Voted(
         address indexed federator,
         bytes32 indexed transactionHash,
@@ -134,14 +134,14 @@ contract Federation is Initializable, UpgradableOwnable {
         emit BridgeChanged(_bridge);
     }
 
-    function setBridgeNFT(address _bridgeNFT) external onlyOwner {
-      _setBridgeNFT(_bridgeNFT);
+    function setNFTBridge(address _NFTBridge) external onlyOwner {
+      _setNFTBridge(_NFTBridge);
     }
 
-    function _setBridgeNFT(address _bridgeNFT) internal {
-      require(_bridgeNFT != NULL_ADDRESS, "Federation: Empty NFT bridge");
-      bridgeNFT = INFTBridge(_bridgeNFT);
-      emit BridgeNFTChanged(_bridgeNFT);
+    function _setNFTBridge(address _NFTBridge) internal {
+      require(_NFTBridge != NULL_ADDRESS, "Federation: Empty NFT bridge");
+      NFTBridge = INFTBridge(_NFTBridge);
+      emit NFTBridgeChanged(_NFTBridge);
     }
 
     function validateTransaction(bytes32 transactionId) internal view returns(bool) {
@@ -152,13 +152,13 @@ contract Federation is Initializable, UpgradableOwnable {
     /**
       @notice Vote in a transaction, if it has enough votes it accepts the transfer
       @dev Always return true
-      @param originalTokenAddress The address of the original token in the main chain
+      @param originalTokenAddress The address of the token in the origin chain
       @param sender The address who solicited the cross token
-      @param receiver Who is going to receive the token in the side chain
+      @param receiver Who is going to receive the token in the opposite chain
       @param number Could be the amount if tokenType == COIN or the tokenId if tokenType == NFT
-      @param blockHash The block hash of the transaction that occurs the cross event
-      @param transactionHash The transaction that occurs the cross event
-      @param logIndex index of log
+      @param blockHash The block hash in which the transaction with the cross event occurred
+      @param transactionHash The transaction in which the cross event occurred
+      @param logIndex Index of the event in the logs
       @param tokenType Is the type of bridge to be used
       @return True
      */
@@ -241,8 +241,8 @@ contract Federation is Initializable, UpgradableOwnable {
     TokenType tokenType
   ) internal {
     if (tokenType == TokenType.NFT) {
-      require(bridgeNFT != INFTBridge(0), "Federation: Empty bridgeNFT");
-      bridgeNFT.acceptTransfer(
+      require(NFTBridge != INFTBridge(0), "Federation: Empty NFTBridge");
+      NFTBridge.acceptTransfer(
         originalTokenAddress,
         sender,
         receiver,
@@ -254,7 +254,6 @@ contract Federation is Initializable, UpgradableOwnable {
       return;
     }
 
-    // if it is not the NFT token type it should send as coin
     bridge.acceptTransfer(
       originalTokenAddress,
       sender,

--- a/bridge/contracts/Federation.sol
+++ b/bridge/contracts/Federation.sol
@@ -151,41 +151,39 @@ contract Federation is Initializable, UpgradableOwnable {
 
     /**
       @notice Vote in a transaction, if it has enough votes it accepts the transfer
-      @dev Always return true
-      @param originalTokenAddress The address of the token in the origin chain
+      @param originalTokenAddress The address of the token in the origin (main) chain
       @param sender The address who solicited the cross token
       @param receiver Who is going to receive the token in the opposite chain
-      @param number Could be the amount if tokenType == COIN or the tokenId if tokenType == NFT
+      @param value Could be the amount if tokenType == COIN or the tokenId if tokenType == NFT
       @param blockHash The block hash in which the transaction with the cross event occurred
       @param transactionHash The transaction in which the cross event occurred
       @param logIndex Index of the event in the logs
       @param tokenType Is the type of bridge to be used
-      @return True
      */
     function voteTransaction(
       address originalTokenAddress,
       address payable sender,
       address payable receiver,
-      uint256 number,
+      uint256 value,
       bytes32 blockHash,
       bytes32 transactionHash,
       uint32 logIndex,
       TokenType tokenType
-    ) public onlyMember returns(bool) {
+    ) public onlyMember {
         bytes32 transactionId = getTransactionId(
             originalTokenAddress,
             sender,
             receiver,
-            number,
+            value,
             blockHash,
             transactionHash,
             logIndex
         );
         if (processed[transactionId])
-            return true;
+            return;
 
         if (votes[transactionId][_msgSender()])
-            return true;
+            return;
 
         votes[transactionId][_msgSender()] = true;
         emit Voted(
@@ -195,7 +193,7 @@ contract Federation is Initializable, UpgradableOwnable {
             originalTokenAddress,
             sender,
             receiver,
-            number,
+            value,
             blockHash,
             logIndex
         );
@@ -206,7 +204,7 @@ contract Federation is Initializable, UpgradableOwnable {
               originalTokenAddress,
               sender,
               receiver,
-              number,
+              value,
               blockHash,
               transactionHash,
               logIndex,
@@ -220,21 +218,19 @@ contract Federation is Initializable, UpgradableOwnable {
                 originalTokenAddress,
                 sender,
                 receiver,
-                number,
+                value,
                 blockHash,
                 logIndex
             );
-            return true;
+            return;
         }
-
-        return true;
     }
 
   function acceptTransfer(
     address originalTokenAddress,
     address payable sender,
     address payable receiver,
-    uint256 number,
+    uint256 value,
     bytes32 blockHash,
     bytes32 transactionHash,
     uint32 logIndex,
@@ -246,7 +242,7 @@ contract Federation is Initializable, UpgradableOwnable {
         originalTokenAddress,
         sender,
         receiver,
-        number,
+        value,
         blockHash,
         transactionHash,
         logIndex
@@ -258,7 +254,7 @@ contract Federation is Initializable, UpgradableOwnable {
       originalTokenAddress,
       sender,
       receiver,
-      number,
+      value,
       blockHash,
       transactionHash,
       logIndex

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -141,19 +141,19 @@ contract NFTBridge is
     bytes32 _transactionHash,
     uint32 _logIndex
   ) external override whenNotPaused nonReentrant {
-    require(_msgSender() == federation, "BridgeNFT: Not Federation");
+    require(_msgSender() == federation, "NFTBridge: Not Federation");
     require(
       knownTokens[_originalTokenAddress] ||
           sideTokenAddressByOriginalTokenAddress[_originalTokenAddress] != NULL_ADDRESS,
-      "BridgeNFT: Unknown token"
+      "NFTBridge: Unknown token"
     );
-    require(_to != NULL_ADDRESS, "BridgeNFT: Null To");
-    require(_from != NULL_ADDRESS, "BridgeNFT: Null From");
-    require(_blockHash != NULL_HASH, "BridgeNFT: Null BlockHash");
-    require(_transactionHash != NULL_HASH, "BridgeNFT: Null TxHash");
+    require(_to != NULL_ADDRESS, "NFTBridge: Null To");
+    require(_from != NULL_ADDRESS, "NFTBridge: Null From");
+    require(_blockHash != NULL_HASH, "NFTBridge: Null BlockHash");
+    require(_transactionHash != NULL_HASH, "NFTBridge: Null TxHash");
     require(
       transactionDataHashes[_transactionHash] == bytes32(0),
-      "BridgeNFT: Already accepted"
+      "NFTBridge: Already accepted"
     );
 
     bytes32 _transactionDataHash = getTransactionDataHash(
@@ -164,7 +164,7 @@ contract NFTBridge is
       _logIndex
     );
     // Do not remove, claimed will also have transactions previously processed using older bridge versions
-    require(!claimed[_transactionDataHash], "Bridge: Already claimed");
+    require(!claimed[_transactionDataHash], "NFTBridge: Already claimed");
 
     transactionDataHashes[_transactionHash] = _transactionDataHash;
     originalTokenAddresses[_transactionHash] = _originalTokenAddress;
@@ -188,9 +188,9 @@ contract NFTBridge is
     string calldata _baseURI,
     string calldata _contractURI
   ) external onlyOwner {
-    require(_originalTokenAddress != NULL_ADDRESS, "Bridge: Null original token address");
+    require(_originalTokenAddress != NULL_ADDRESS, "NFTBridge: Null original token address");
     address sideTokenAddress = sideTokenAddressByOriginalTokenAddress[_originalTokenAddress];
-    require(sideTokenAddress == NULL_ADDRESS, "Bridge: Side token already exists");
+    require(sideTokenAddress == NULL_ADDRESS, "NFTBridge: Side token already exists");
     string memory sideTokenSymbol = string(abi.encodePacked(symbolPrefix, _originalTokenSymbol));
 
     // Create side token
@@ -214,7 +214,7 @@ contract NFTBridge is
   function claimFallback(ClaimData calldata _claimData) external override returns (uint256 receivedAmount) {
     require(
       _msgSender() == senderAddresses[_claimData.transactionHash],
-      "Bridge: invalid sender"
+      "NFTBridge: invalid sender"
     );
     receivedAmount = _claim(
       _claimData,
@@ -259,13 +259,13 @@ contract NFTBridge is
     bytes32 _s
   ) external override returns (uint256 receivedAmount) {
     // solhint-disable-next-line not-rely-on-time
-    require(_deadline >= block.timestamp, "Bridge: EXPIRED");
+    require(_deadline >= block.timestamp, "NFTBridge: EXPIRED");
 
     bytes32 digest = getDigest(_claimData, _relayer, _fee, _deadline);
     address recoveredAddress = ecrecover(digest, _v, _r, _s);
     require(
       _claimData.to != address(0) && recoveredAddress == _claimData.to,
-      "Bridge: INVALID_SIGNATURE"
+      "NFTBridge: INVALID_SIGNATURE"
     );
 
     receivedAmount = _claim(_claimData, _claimData.to, _relayer, _fee);
@@ -281,7 +281,7 @@ contract NFTBridge is
     address originalTokenAddress = originalTokenAddresses[
       _claimData.transactionHash
     ];
-    require(originalTokenAddress != NULL_ADDRESS, "Bridge: Tx not crossed");
+    require(originalTokenAddress != NULL_ADDRESS, "NFTBridge: Tx not crossed");
 
     bytes32 transactionDataHash = getTransactionDataHash(
       _claimData.to,
@@ -292,9 +292,9 @@ contract NFTBridge is
     );
     require(
       transactionDataHashes[_claimData.transactionHash] == transactionDataHash,
-      "Bridge: Wrong txDataHash"
+      "NFTBridge: Wrong txDataHash"
     );
-    require(!claimed[transactionDataHash], "Bridge: Already claimed");
+    require(!claimed[transactionDataHash], "NFTBridge: Already claimed");
 
     claimed[transactionDataHash] = true;
     if (knownTokens[originalTokenAddress]) {
@@ -341,7 +341,7 @@ contract NFTBridge is
       // address sideToken = mappedTokens[_originalTokenAddress];
       // uint256 granularity = IERC777(sideToken).granularity();
       // uint256 formattedAmount = _amount.mul(granularity);
-      // require(_fee <= formattedAmount, "Bridge: fee too high");
+      // require(_fee <= formattedAmount, "NFTBridge: fee too high");
       // receivedAmount = formattedAmount - _fee;
       // ISideToken(sideToken).mint(_receiver, receivedAmount, "", "");
       // if(_fee > 0) {
@@ -360,7 +360,7 @@ contract NFTBridge is
     uint256 decimals = LibUtils.getDecimals(_originalTokenAddress);
     //As side tokens are ERC777 they will always have 18 decimals
     uint256 formattedAmount = _amount.div(uint256(10)**(18 - decimals));
-    require(_fee <= formattedAmount, "Bridge: fee too high");
+    require(_fee <= formattedAmount, "NFTBridge: fee too high");
     receivedAmount = formattedAmount - _fee;
     if (address(wrappedCurrency) == _originalTokenAddress) {
       wrappedCurrency.withdraw(formattedAmount);
@@ -470,13 +470,13 @@ contract NFTBridge is
   }
 
   function changeFederation(address payable newFederation) external onlyOwner {
-    require(newFederation != NULL_ADDRESS, "Bridge: Federation is empty");
+    require(newFederation != NULL_ADDRESS, "NFTBridge: Federation is empty");
     federation = newFederation;
     emit FederationChanged(federation);
   }
 
   function changeAllowTokens(address newAllowTokens) external onlyOwner {
-    require(newAllowTokens != NULL_ADDRESS, "Bridge: AllowTokens is empty");
+    require(newAllowTokens != NULL_ADDRESS, "NFTBridge: AllowTokens is empty");
     allowTokens = IAllowTokens(newAllowTokens);
     emit AllowTokensChanged(newAllowTokens);
   }
@@ -488,7 +488,7 @@ contract NFTBridge is
   function changeSideTokenFactory(address newSideNFTTokenFactory) external onlyOwner {
     require(
       newSideNFTTokenFactory != NULL_ADDRESS,
-      "Bridge: empty SideTokenFactory"
+      "NFTBridge: empty SideTokenFactory"
     );
     sideTokenFactory = ISideNFTTokenFactory(newSideNFTTokenFactory);
     emit SideTokenFactoryChanged(newSideNFTTokenFactory);
@@ -500,7 +500,7 @@ contract NFTBridge is
   }
 
   function setWrappedCurrency(address _wrappedCurrency) external onlyOwner {
-    require(_wrappedCurrency != NULL_ADDRESS, "Bridge: wrapp is empty");
+    require(_wrappedCurrency != NULL_ADDRESS, "NFTBridge: wrapp is empty");
     wrappedCurrency = IWrapped(_wrappedCurrency);
     emit WrappedCurrencyChanged(_wrappedCurrency);
   }

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -141,19 +141,19 @@ contract NFTBridge is
     bytes32 _transactionHash,
     uint32 _logIndex
   ) external override whenNotPaused nonReentrant {
-    require(_msgSender() == federation, "Bridge: Not Federation");
+    require(_msgSender() == federation, "BridgeNFT: Not Federation");
     require(
       knownTokens[_originalTokenAddress] ||
           sideTokenAddressByOriginalTokenAddress[_originalTokenAddress] != NULL_ADDRESS,
-      "Bridge: Unknown token"
+      "BridgeNFT: Unknown token"
     );
-    require(_to != NULL_ADDRESS, "Bridge: Null To");
-    require(_from != NULL_ADDRESS, "Bridge: Null From");
-    require(_blockHash != NULL_HASH, "Bridge: Null BlockHash");
-    require(_transactionHash != NULL_HASH, "Bridge: Null TxHash");
+    require(_to != NULL_ADDRESS, "BridgeNFT: Null To");
+    require(_from != NULL_ADDRESS, "BridgeNFT: Null From");
+    require(_blockHash != NULL_HASH, "BridgeNFT: Null BlockHash");
+    require(_transactionHash != NULL_HASH, "BridgeNFT: Null TxHash");
     require(
       transactionDataHashes[_transactionHash] == bytes32(0),
-      "Bridge: Already accepted"
+      "BridgeNFT: Already accepted"
     );
 
     bytes32 _transactionDataHash = getTransactionDataHash(

--- a/bridge/test/Federation_test.js
+++ b/bridge/test/Federation_test.js
@@ -14,8 +14,6 @@ contract('Federation', async function (accounts) {
     const federator2 = accounts[3];
     const federator3 = accounts[4];
     const bridge = utils.getRandomAddress();
-    const TOKEN_TYPE_COIN = 0;
-    // const TOKEN_TYPE_NFT = 1;
 
     before(async function () {
         await utils.saveState();
@@ -390,7 +388,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -449,7 +447,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1})
                 );
 
@@ -489,7 +487,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -534,7 +532,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -556,7 +554,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator2}
                 );
                 utils.checkRcpt(receipt);
@@ -600,7 +598,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -622,7 +620,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator2}
                 );
                 utils.checkRcpt(receipt);
@@ -654,7 +652,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
 
@@ -682,7 +680,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator2}
                 );
 
@@ -714,7 +712,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
 
@@ -742,7 +740,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator2}
                 );
 
@@ -773,7 +771,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
 
@@ -801,7 +799,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator2}
                 );
 
@@ -829,7 +827,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator3}
                 );
 
@@ -851,7 +849,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
 
@@ -879,7 +877,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator2}
                 );
 
@@ -906,7 +904,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator3}
                 );
 
@@ -929,7 +927,7 @@ contract('Federation', async function (accounts) {
 
             it('should fail if not federators member', async function() {
                 await utils.expectThrow(this.federators.voteTransaction(originalTokenAddress,
-                    anAccount, anAccount, amount, blockHash, transactionHash, logIndex, TOKEN_TYPE_COIN));
+                    anAccount, anAccount, amount, blockHash, transactionHash, logIndex, utils.tokenType.COIN));
             });
 
             it('voteTransaction should be successfull if already voted', async function() {
@@ -953,7 +951,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -969,7 +967,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    TOKEN_TYPE_COIN,
+                    utils.tokenType.COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);

--- a/bridge/test/Federation_test.js
+++ b/bridge/test/Federation_test.js
@@ -14,6 +14,8 @@ contract('Federation', async function (accounts) {
     const federator2 = accounts[3];
     const federator3 = accounts[4];
     const bridge = utils.getRandomAddress();
+    const TOKEN_TYPE_COIN = 0;
+    // const TOKEN_TYPE_NFT = 1;
 
     before(async function () {
         await utils.saveState();
@@ -388,6 +390,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -446,6 +449,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1})
                 );
 
@@ -485,6 +489,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -529,6 +534,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -550,6 +556,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator2}
                 );
                 utils.checkRcpt(receipt);
@@ -593,6 +600,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -614,6 +622,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator2}
                 );
                 utils.checkRcpt(receipt);
@@ -645,6 +654,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
 
@@ -672,6 +682,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator2}
                 );
 
@@ -703,7 +714,9 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    {from: federator1});
+                    TOKEN_TYPE_COIN,
+                    {from: federator1}
+                );
 
                 let transactionId = await this.federators.getTransactionId(
                     originalTokenAddress,
@@ -729,6 +742,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator2}
                 );
 
@@ -759,6 +773,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
 
@@ -786,6 +801,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator2}
                 );
 
@@ -813,6 +829,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator3}
                 );
 
@@ -834,6 +851,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
 
@@ -861,6 +879,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator2}
                 );
 
@@ -887,6 +906,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator3}
                 );
 
@@ -909,7 +929,7 @@ contract('Federation', async function (accounts) {
 
             it('should fail if not federators member', async function() {
                 await utils.expectThrow(this.federators.voteTransaction(originalTokenAddress,
-                    anAccount, anAccount, amount, blockHash, transactionHash, logIndex));
+                    anAccount, anAccount, amount, blockHash, transactionHash, logIndex, TOKEN_TYPE_COIN));
             });
 
             it('voteTransaction should be successfull if already voted', async function() {
@@ -933,6 +953,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);
@@ -948,6 +969,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
+                    TOKEN_TYPE_COIN,
                     {from: federator1}
                 );
                 utils.checkRcpt(receipt);

--- a/bridge/test/Federation_test.js
+++ b/bridge/test/Federation_test.js
@@ -1049,7 +1049,7 @@ contract('Federation', async function (accounts) {
                 await this.federators.setNFTBridge(this.NFTBridge.address);
               });
 
-              it.only('should vote successfully', async function() {
+              it('should vote successfully', async function() {
                 let receipt = await this.NFTtoken.safeMint(deployer, tokenId, {
                   from: deployer,
                 });

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -97,7 +97,7 @@ contract("Bridge NFT", async function(accounts) {
     });
     utils.checkRcpt(receipt);
   };
-  
+
   describe("Main NFT network", async function() {
     it("should retrieve the version", async function() {
       const result = await this.bridgeNft.version();
@@ -610,7 +610,7 @@ contract("Bridge NFT", async function(accounts) {
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: anAccount}
             ),
-            "Bridge: Not Federation"
+            "BridgeNFT: Not Federation"
         );
       });
 
@@ -621,7 +621,7 @@ contract("Bridge NFT", async function(accounts) {
                 unknownTokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "Bridge: Unknown token"
+            "BridgeNFT: Unknown token"
         );
       });
 
@@ -631,7 +631,7 @@ contract("Bridge NFT", async function(accounts) {
                 tokenAddress, anAccount, utils.NULL_ADDRESS, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "Bridge: Null To"
+            "BridgeNFT: Null To"
         );
       });
 
@@ -641,7 +641,7 @@ contract("Bridge NFT", async function(accounts) {
                 tokenAddress, utils.NULL_ADDRESS, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "Bridge: Null From"
+            "BridgeNFT: Null From"
         );
       });
 
@@ -651,7 +651,7 @@ contract("Bridge NFT", async function(accounts) {
                 tokenAddress, anAccount, anotherAccount, tokenId, utils.NULL_HASH, transactionHash, logIndex,
                 {from: federation}
             ),
-            "Bridge: Null BlockHash"
+            "BridgeNFT: Null BlockHash"
         );
       });
 
@@ -661,7 +661,7 @@ contract("Bridge NFT", async function(accounts) {
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, utils.NULL_HASH, logIndex,
                 {from: federation}
             ),
-            "Bridge: Null TxHash"
+            "BridgeNFT: Null TxHash"
         );
       });
 
@@ -672,7 +672,7 @@ contract("Bridge NFT", async function(accounts) {
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "Bridge: Already accepted"
+            "BridgeNFT: Already accepted"
         );
       });
     });

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -63,9 +63,9 @@ contract("Bridge NFT", async function(accounts) {
     });
 
     this.sideTokenFactory = await SideNFTTokenFactory.new();
-    this.bridgeNft = await NftBridge.new();
+    this.NFTBridge = await NftBridge.new();
 
-    await this.bridgeNft.methods[
+    await this.NFTBridge.methods[
       "initialize(address,address,address,address,string)"
     ](
       bridgeManager,
@@ -75,8 +75,8 @@ contract("Bridge NFT", async function(accounts) {
       sideTokenSymbolPrefix
     );
 
-    await this.sideTokenFactory.transferPrimary(this.bridgeNft.address);
-    await this.allowTokens.transferPrimary(this.bridgeNft.address, {
+    await this.sideTokenFactory.transferPrimary(this.NFTBridge.address);
+    await this.allowTokens.transferPrimary(this.NFTBridge.address, {
       from: bridgeOwner,
     });
   });
@@ -100,70 +100,70 @@ contract("Bridge NFT", async function(accounts) {
 
   describe("Main NFT network", async function() {
     it("should retrieve the version", async function() {
-      const result = await this.bridgeNft.version();
+      const result = await this.NFTBridge.version();
       assert.equal(result, "v1");
     });
 
     describe("owner", async function() {
       it("check manager", async function() {
-        const manager = await this.bridgeNft.owner();
+        const manager = await this.NFTBridge.owner();
         assert.equal(manager, bridgeManager);
       });
 
       it("change manager", async function() {
-        const receipt = await this.bridgeNft.transferOwnership(
+        const receipt = await this.NFTBridge.transferOwnership(
           newBridgeManager,
           { from: bridgeManager }
         );
         utils.checkRcpt(receipt);
-        const manager = await this.bridgeNft.owner();
+        const manager = await this.NFTBridge.owner();
         assert.equal(manager, newBridgeManager);
       });
 
       it("only manager can change manager", async function() {
         await truffleAssert.fails(
-          this.bridgeNft.transferOwnership(newBridgeManager),
+          this.NFTBridge.transferOwnership(newBridgeManager),
           truffleAssert.ErrorType.REVERT,
           "Ownable: caller is not the owner"
         );
-        const manager = await this.bridgeNft.owner();
+        const manager = await this.NFTBridge.owner();
         assert.equal(manager, bridgeManager);
       });
 
       it("check federation", async function() {
-        const federationAddress = await this.bridgeNft.getFederation();
+        const federationAddress = await this.NFTBridge.getFederation();
         assert.equal(federationAddress, federation);
       });
 
       it("change federation", async function() {
-        const receipt = await this.bridgeNft.changeFederation(
+        const receipt = await this.NFTBridge.changeFederation(
           newBridgeManager,
           { from: bridgeManager }
         );
         utils.checkRcpt(receipt);
-        const federationAddress = await this.bridgeNft.getFederation();
+        const federationAddress = await this.NFTBridge.getFederation();
         assert.equal(federationAddress, newBridgeManager);
       });
 
       it("only manager can change the federation", async function() {
         await truffleAssert.fails(
-          this.bridgeNft.changeFederation(newBridgeManager),
+          this.NFTBridge.changeFederation(newBridgeManager),
           truffleAssert.ErrorType.REVERT,
           "Ownable: caller is not the owner"
         );
-        const federationAddress = await this.bridgeNft.getFederation();
+        const federationAddress = await this.NFTBridge.getFederation();
         assert.equal(federationAddress, federation);
       });
 
       it("change federation new fed cant be null", async function() {
         await truffleAssert.fails(
-          this.bridgeNft.changeFederation(utils.NULL_ADDRESS, {
+          this.NFTBridge.changeFederation(utils.NULL_ADDRESS, {
             from: bridgeManager,
           }),
           truffleAssert.ErrorType.REVERT,
           "Bridge: Federation is empty"
         );
-        const federationAddress = await this.bridgeNft.getFederation();
+        const federationAddress = await this.NFTBridge.getFederation();
         assert.equal(federationAddress, federation);
       });
     });
@@ -172,13 +172,13 @@ contract("Bridge NFT", async function(accounts) {
       it("receives ERC721 NFT correctly with token URI", async function() {
         let totalSupply = 0; // is the amount of nft minted
 
-        await mintAndApprove(this.token, this.bridgeNft.address);
+        await mintAndApprove(this.token, this.NFTBridge.address);
         totalSupply++;
 
         let receipt = await this.token.setTokenURI(defaultTokenId, defaultTokenURI);
         utils.checkRcpt(receipt);
 
-        receipt = await this.bridgeNft.receiveTokensTo(
+        receipt = await this.NFTBridge.receiveTokensTo(
           this.token.address,
           anAccount,
           defaultTokenId,
@@ -205,10 +205,10 @@ contract("Bridge NFT", async function(accounts) {
       it("receives ERC721 NFT correctly with base URI and without token URI set", async function() {
         let totalSupply = 0;
 
-        await mintAndApprove(this.token, this.bridgeNft.address);
+        await mintAndApprove(this.token, this.NFTBridge.address);
         totalSupply++;
 
-        let receipt = await this.bridgeNft.receiveTokensTo(
+        let receipt = await this.NFTBridge.receiveTokensTo(
           this.token.address,
           anAccount,
           defaultTokenId,
@@ -234,10 +234,10 @@ contract("Bridge NFT", async function(accounts) {
         let totalSupply = 0;
 
         await this.token.setBaseURI('');
-        await mintAndApprove(this.token, this.bridgeNft.address);
+        await mintAndApprove(this.token, this.NFTBridge.address);
         totalSupply++;
 
-        let receipt = await this.bridgeNft.receiveTokensTo(
+        let receipt = await this.NFTBridge.receiveTokensTo(
           this.token.address,
           anAccount,
           defaultTokenId,
@@ -263,13 +263,13 @@ contract("Bridge NFT", async function(accounts) {
         let totalSupply = 0;
 
         await this.token.setBaseURI('');
-        await mintAndApprove(this.token, this.bridgeNft.address);
+        await mintAndApprove(this.token, this.NFTBridge.address);
         totalSupply++;
 
         let receipt = await this.token.setTokenURI(defaultTokenId, defaultTokenURI);
         utils.checkRcpt(receipt);
 
-        receipt = await this.bridgeNft.receiveTokensTo(
+        receipt = await this.NFTBridge.receiveTokensTo(
           this.token.address,
           anAccount,
           defaultTokenId,
@@ -294,17 +294,17 @@ contract("Bridge NFT", async function(accounts) {
       describe("fixed fee", async function() {
         it("should send fee to federator correctly", async function() {
           const fixedFee = new BN("15");
-          let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
+          let receipt = await this.NFTBridge.setFixedFee(fixedFee, {
             from: bridgeManager,
           });
           utils.checkRcpt(receipt);
 
-          await mintAndApprove(this.token, this.bridgeNft.address);
+          await mintAndApprove(this.token, this.NFTBridge.address);
 
           const tokenOwnerBalance = await utils.getEtherBalance(tokenOwner);
           const federatorBalance = await utils.getEtherBalance(federation);
 
-          const tx = await this.bridgeNft.receiveTokensTo(
+          const tx = await this.NFTBridge.receiveTokensTo(
             this.token.address,
             anAccount,
             defaultTokenId,
@@ -336,17 +336,17 @@ contract("Bridge NFT", async function(accounts) {
 
         it("should send fixed fee + 10 to federator correctly and the remaining value sent it back to the sender", async function() {
           const fixedFee = new BN("15");
-          let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
+          let receipt = await this.NFTBridge.setFixedFee(fixedFee, {
             from: bridgeManager,
           });
           utils.checkRcpt(receipt);
 
-          await mintAndApprove(this.token, this.bridgeNft.address);
+          await mintAndApprove(this.token, this.NFTBridge.address);
 
           const tokenOwnerBalance = await utils.getEtherBalance(tokenOwner);
           const federatorBalance = await utils.getEtherBalance(federation);
 
-          const tx = await this.bridgeNft.receiveTokensTo(
+          const tx = await this.NFTBridge.receiveTokensTo(
             this.token.address,
             anAccount,
             defaultTokenId,
@@ -377,15 +377,15 @@ contract("Bridge NFT", async function(accounts) {
         });
 
         it("should reamin the same balance for the Federator, because the fixed fee is zero", async function() {
-          let receipt = await this.bridgeNft.setFixedFee(new BN(0), {
+          let receipt = await this.NFTBridge.setFixedFee(new BN(0), {
             from: bridgeManager,
           });
           utils.checkRcpt(receipt);
 
-          await mintAndApprove(this.token, this.bridgeNft.address);
+          await mintAndApprove(this.token, this.NFTBridge.address);
           const federatorBalance = await utils.getEtherBalance(federation);
 
-          const tx = await this.bridgeNft.receiveTokensTo(
+          const tx = await this.NFTBridge.receiveTokensTo(
             this.token.address,
             anAccount,
             defaultTokenId,
@@ -403,16 +403,16 @@ contract("Bridge NFT", async function(accounts) {
         });
 
         it("should fail because the sender doesn't have balance", async function() {
-          await mintAndApprove(this.token, this.bridgeNft.address);
+          await mintAndApprove(this.token, this.NFTBridge.address);
 
           const fixedFee = await utils.getEtherBalance(tokenOwner);
-          let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
+          let receipt = await this.NFTBridge.setFixedFee(fixedFee, {
             from: bridgeManager,
           });
           utils.checkRcpt(receipt);
 
           await truffleAssert.fails(
-            this.bridgeNft.receiveTokensTo(
+            this.NFTBridge.receiveTokensTo(
               this.token.address,
               anAccount,
               defaultTokenId,
@@ -426,16 +426,16 @@ contract("Bridge NFT", async function(accounts) {
         });
 
         it("should fail because the sent value is smaller than fixed fee", async function() {
-          await mintAndApprove(this.token, this.bridgeNft.address);
+          await mintAndApprove(this.token, this.NFTBridge.address);
 
           const fixedFee = new BN(15);
-          let receipt = await this.bridgeNft.setFixedFee(fixedFee, {
+          let receipt = await this.NFTBridge.setFixedFee(fixedFee, {
             from: bridgeManager,
           });
           utils.checkRcpt(receipt);
 
           await truffleAssert.fails(
-            this.bridgeNft.receiveTokensTo(
+            this.NFTBridge.receiveTokensTo(
               this.token.address,
               anAccount,
               defaultTokenId,
@@ -466,7 +466,7 @@ contract("Bridge NFT", async function(accounts) {
       });
 
       it("creates token correctly and emits expected event when inputs are correct", async function() {
-        let receipt = await this.bridgeNft.createSideNFTToken(
+        let receipt = await this.NFTBridge.createSideNFTToken(
             tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
         );
 
@@ -489,12 +489,12 @@ contract("Bridge NFT", async function(accounts) {
         const newSideNFTTokenBaseURI = await newSideNFTToken.baseURI();
         assert.equal(baseURI, newSideNFTTokenBaseURI);
 
-        let sideTokenAddressMappedByBridge = await this.bridgeNft.sideTokenAddressByOriginalTokenAddress(
+        let sideTokenAddressMappedByBridge = await this.NFTBridge.sideTokenAddressByOriginalTokenAddress(
           tokenAddress
         );
         assert.equal(newSideNFTTokenAddress, sideTokenAddressMappedByBridge);
 
-        let tokenAddressMappedByBridge = await this.bridgeNft.originalTokenAddressBySideTokenAddress(
+        let tokenAddressMappedByBridge = await this.NFTBridge.originalTokenAddressBySideTokenAddress(
           newSideNFTTokenAddress
         );
         assert.equal(tokenAddress, tokenAddressMappedByBridge);
@@ -502,7 +502,7 @@ contract("Bridge NFT", async function(accounts) {
 
       it("fails to create side NFT token if the original token address is a null address", async function() {
         await truffleAssert.fails(
-            this.bridgeNft.createSideNFTToken(
+            this.NFTBridge.createSideNFTToken(
                 utils.NULL_ADDRESS, symbol, name, baseURI, contractURI, {from: bridgeManager}
             ),
             truffleAssert.ErrorType.REVERT,
@@ -511,14 +511,14 @@ contract("Bridge NFT", async function(accounts) {
       });
 
       it("fails to create side NFT token if side token address already exists", async function() {
-        let receipt = await this.bridgeNft.createSideNFTToken(
+        let receipt = await this.NFTBridge.createSideNFTToken(
           tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
         );
 
         truffleAssert.eventEmitted(receipt, newSideNFTTokenEventType);
 
         await truffleAssert.fails(
-          this.bridgeNft.createSideNFTToken(
+          this.NFTBridge.createSideNFTToken(
             tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
           ),
           truffleAssert.ErrorType.REVERT,
@@ -528,7 +528,7 @@ contract("Bridge NFT", async function(accounts) {
 
       it("fails to create side NFT token if transaction sender is not bridge manager", async function() {
         await truffleAssert.fails(
-          this.bridgeNft.createSideNFTToken(
+          this.NFTBridge.createSideNFTToken(
             tokenAddress, symbol, name, baseURI, contractURI, {from: anAccount}
           ),
           truffleAssert.ErrorType.REVERT,
@@ -554,7 +554,7 @@ contract("Bridge NFT", async function(accounts) {
         baseURI = await this.token.baseURI();
         contractURI = await this.token.contractURI();
         tokenAddress = this.token.address;
-        let receipt = await this.bridgeNft.createSideNFTToken(
+        let receipt = await this.NFTBridge.createSideNFTToken(
             tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
         );
         utils.checkRcpt(receipt);
@@ -565,13 +565,13 @@ contract("Bridge NFT", async function(accounts) {
       });
 
       async function assertAcceptTransferSuccessfulResult(tokenAddress, tokenId, blockHash, transactionHash, logIndex) {
-        const receipt = await this.bridgeNft.acceptTransfer(
+        const receipt = await this.NFTBridge.acceptTransfer(
             tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
             {from: federation}
         );
         utils.checkRcpt(receipt);
 
-        const expectedTransactionDataHash = await this.bridgeNft.getTransactionDataHash(
+        const expectedTransactionDataHash = await this.NFTBridge.getTransactionDataHash(
             anotherAccount, tokenId, blockHash, transactionHash, logIndex
         );
 
@@ -580,13 +580,13 @@ contract("Bridge NFT", async function(accounts) {
       }
 
       async function assertAcceptTransferPublicMembersCorrectness(transactionHash, expectedTransactionDataHash, tokenAddress) {
-        let transactionDataHash = await this.bridgeNft.transactionDataHashes(transactionHash);
+        let transactionDataHash = await this.NFTBridge.transactionDataHashes(transactionHash);
         assert.equal(expectedTransactionDataHash, transactionDataHash);
 
-        let originalTokenAddressForTransactionHash = await this.bridgeNft.originalTokenAddresses(transactionHash);
+        let originalTokenAddressForTransactionHash = await this.NFTBridge.originalTokenAddresses(transactionHash);
         assert.equal(tokenAddress, originalTokenAddressForTransactionHash)
 
-        let senderAddressForTransactionHash = await this.bridgeNft.senderAddresses(transactionHash);
+        let senderAddressForTransactionHash = await this.NFTBridge.senderAddresses(transactionHash);
         assert.equal(anAccount, senderAddressForTransactionHash);
       }
 
@@ -606,73 +606,73 @@ contract("Bridge NFT", async function(accounts) {
 
       it("throws an error when an address other than the federation sends the transaction", async function () {
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: anAccount}
             ),
-            "BridgeNFT: Not Federation"
+            "NFTBridge: Not Federation"
         );
       });
 
       it("throws an error when token is unknown", async function () {
         const unknownTokenAddress = utils.getRandomAddress();
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 unknownTokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "BridgeNFT: Unknown token"
+            "NFTBridge: Unknown token"
         );
       });
 
       it("throws an error when 'to' address is null", async function () {
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, utils.NULL_ADDRESS, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "BridgeNFT: Null To"
+            "NFTBridge: Null To"
         );
       });
 
       it("throws an error when 'from' address is null", async function () {
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 tokenAddress, utils.NULL_ADDRESS, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "BridgeNFT: Null From"
+            "NFTBridge: Null From"
         );
       });
 
       it("throws an error when block hash is null", async function () {
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, utils.NULL_HASH, transactionHash, logIndex,
                 {from: federation}
             ),
-            "BridgeNFT: Null BlockHash"
+            "NFTBridge: Null BlockHash"
         );
       });
 
       it("throws an error when transaction hash is null", async function () {
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, utils.NULL_HASH, logIndex,
                 {from: federation}
             ),
-            "BridgeNFT: Null TxHash"
+            "NFTBridge: Null TxHash"
         );
       });
 
       it("throws an error when transaction was already accepted", async function () {
         await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash, logIndex);
         await truffleAssert.fails(
-            this.bridgeNft.acceptTransfer(
+            this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
                 {from: federation}
             ),
-            "BridgeNFT: Already accepted"
+            "NFTBridge: Already accepted"
         );
       });
     });

--- a/bridge/test/utils.js
+++ b/bridge/test/utils.js
@@ -200,6 +200,11 @@ function getRandomHash() {
   return randomHex(HASH_LENGTH);
 }
 
+const tokenType = {
+  COIN: 0,
+  NFT: 1
+};
+
 module.exports = {
   getEtherBalance: getEtherBalance,
   getGasUsedByTx: getGasUsedByTx,
@@ -218,4 +223,5 @@ module.exports = {
   revertState: revertState,
   getRandomAddress: getRandomAddress,
   getRandomHash: getRandomHash,
+  tokenType,
 };

--- a/federator/src/contracts/IFederationV2.js
+++ b/federator/src/contracts/IFederationV2.js
@@ -38,10 +38,11 @@ module.exports = class IFederationV2 {
             paramsObj.originalTokenAddress,
             paramsObj.sender,
             paramsObj.receiver,
-            paramsObj.amount,
+            paramsObj.number,
             paramsObj.blockHash,
             paramsObj.transactionHash,
-            paramsObj.logIndex
+            paramsObj.logIndex,
+            paramsObj.tokenType,
         );
     }
 

--- a/federator/src/contracts/IFederationV2.js
+++ b/federator/src/contracts/IFederationV2.js
@@ -38,7 +38,7 @@ module.exports = class IFederationV2 {
             paramsObj.originalTokenAddress,
             paramsObj.sender,
             paramsObj.receiver,
-            paramsObj.number,
+            paramsObj.amount,
             paramsObj.blockHash,
             paramsObj.transactionHash,
             paramsObj.logIndex,

--- a/federator/src/lib/Federator.js
+++ b/federator/src/lib/Federator.js
@@ -289,7 +289,7 @@ module.exports = class Federator {
               originalTokenAddress: tokenAddress,
               sender,
               receiver,
-              number: amount,
+              amount,
               symbol,
               blockHash,
               transactionHash,

--- a/federator/src/lib/Federator.js
+++ b/federator/src/lib/Federator.js
@@ -7,6 +7,7 @@ const FederationFactory = require('../contracts/FederationFactory');
 const AllowTokensFactory = require('../contracts/AllowTokensFactory');
 const utils = require('./utils');
 const TOKEN_TYPE_COIN = 0;
+
 module.exports = class Federator {
     constructor(config, logger, Web3 = web3) {
 
@@ -287,18 +288,18 @@ module.exports = class Federator {
             this.logger.info(`Voting Transfer ${amount} of originalTokenAddress:${tokenAddress} trough sidechain bridge ${this.config.sidechain.bridge} to receiver ${receiver}`);
 
             let txData = await fedContract.voteTransaction({
-                originalTokenAddress: tokenAddress,
-                sender,
-                receiver,
-                amount,
-                symbol,
-                blockHash,
-                transactionHash,
-                logIndex,
-                decimals,
-                granularity,
-                typeId,
-                TOKEN_TYPE_COIN,
+              originalTokenAddress: tokenAddress,
+              sender,
+              receiver,
+              number: amount,
+              symbol,
+              blockHash,
+              transactionHash,
+              logIndex,
+              decimals,
+              granularity,
+              typeId,
+              tokenType: TOKEN_TYPE_COIN,
             }).encodeABI();
 
             let revertedTxns = {};

--- a/federator/src/lib/Federator.js
+++ b/federator/src/lib/Federator.js
@@ -6,8 +6,6 @@ const BridgeFactory = require('../contracts/BridgeFactory');
 const FederationFactory = require('../contracts/FederationFactory');
 const AllowTokensFactory = require('../contracts/AllowTokensFactory');
 const utils = require('./utils');
-const TOKEN_TYPE_COIN = 0;
-
 module.exports = class Federator {
     constructor(config, logger, Web3 = web3) {
 
@@ -299,7 +297,7 @@ module.exports = class Federator {
               decimals,
               granularity,
               typeId,
-              tokenType: TOKEN_TYPE_COIN,
+              tokenType: utils.tokenType.COIN,
             }).encodeABI();
 
             let revertedTxns = {};

--- a/federator/src/lib/Federator.js
+++ b/federator/src/lib/Federator.js
@@ -6,7 +6,7 @@ const BridgeFactory = require('../contracts/BridgeFactory');
 const FederationFactory = require('../contracts/FederationFactory');
 const AllowTokensFactory = require('../contracts/AllowTokensFactory');
 const utils = require('./utils');
-
+const TOKEN_TYPE_COIN = 0;
 module.exports = class Federator {
     constructor(config, logger, Web3 = web3) {
 
@@ -297,7 +297,8 @@ module.exports = class Federator {
                 logIndex,
                 decimals,
                 granularity,
-                typeId
+                typeId,
+                TOKEN_TYPE_COIN,
             }).encodeABI();
 
             let revertedTxns = {};

--- a/federator/src/lib/utils.js
+++ b/federator/src/lib/utils.js
@@ -195,6 +195,11 @@ function increaseTimestamp(web3, increase) {
     });
 }
 
+const tokenType = {
+  COIN: 0,
+  NFT: 1
+};
+
 module.exports = {
     asyncMine,
     evm_mine,
@@ -213,5 +218,6 @@ module.exports = {
     retry,
     retry3Times,
     getHeartbeatPollingInterval,
-    increaseTimestamp
+    increaseTimestamp,
+    tokenType,
 }


### PR DESCRIPTION
### Federation NFT bridge 

The federation now will handle just 2 bridges with different interfaces (IBridge and INFTBridge)

### Todo 
- add tests for nft bridge

### Description

- Add NFT bridge to Federation contract
- Add doc and comments to variables
- Update Federation tests to have a new bridge 

### How to Test

- Run both `ganache-cli`
- Enter into the bridge directory and run the truffle test in the file `test/Federation_test.js`

#### Case 1

1. Go to bridge directory
```shell
$~ cd bridge
```

2. Run the first ganache-cli
```shell
$~ npm run ganache
```

3. Open another shell and run the ganache mirror
```shell
$~ npm run ganache-mirror
```

4. Run the test file that calls `receiveTokensTo`
```shell
$~ truffle test test/Federation_test.js
```

__Expected Result__
- It should pass the test
![image](https://user-images.githubusercontent.com/17556614/130066074-4f67b54b-c3c7-42dc-9542-1c24fd6110a2.png)

### Checklist

#### Bridge Directory `cd bridge`
- [x] Lint is clean `npm run lint`
- [x] Test is passing `npm run test`
- [x] Contracts are compiling `npm run compile`