### PR TITLE
Add tests for check new methods on federation

### DIFF
--- a/bridge/test/nftbridge/FederationV2_to_federation_test.js
+++ b/bridge/test/nftbridge/FederationV2_to_federation_test.js
@@ -2,7 +2,8 @@ const FederationV2 = artifacts.require('FederationV2');
 const Federation = artifacts.require('Federation');
 const FederationProxy = artifacts.require('FederationProxy');
 const ProxyAdmin = artifacts.require('ProxyAdmin');
-const utils = require('../utils');
+const NftBridge = artifacts.require("NFTBridge");
+const utils = require("../utils");
 
 contract('Federation', async function (accounts) {
   const deployer = accounts[0];
@@ -10,37 +11,83 @@ contract('Federation', async function (accounts) {
   const federator2 = accounts[3];
   const bridge = utils.getRandomAddress();
 
+  beforeEach(async function() {
+    this.federationV2 = await FederationV2.new();
+    this.proxyAdmin = await ProxyAdmin.new();
+    this.federation = await Federation.new();
+    this.nftBridge = await NftBridge.new();
+  });
+
   describe('Upgrate from FederationV2 to Federation', async function () {
+    it('should update the contract version from v2 to v3', async function () {
+      const initData = await this.federationV2.contract.methods.initialize([federator1], 1, bridge, deployer).encodeABI();
+      const federationProxy = await FederationProxy.new(this.federationV2.address, this.proxyAdmin.address, initData);
+      const proxyFederationV2 = new web3.eth.Contract(this.federationV2.abi, federationProxy.address);
 
-    it('should mantain the members from the Federator v2', async function () {
-      this.members  = [federator1, federator2];
-      const federationV2 = await FederationV2.new();
-      const proxyAdmin = await ProxyAdmin.new();
-      const initData = await federationV2.contract.methods.initialize(this.members, 1, bridge, deployer).encodeABI();
-      const federationProxy = await FederationProxy.new(federationV2.address, proxyAdmin.address, initData);
-      const proxyFederationV2 = new web3.eth.Contract(federationV2.abi, federationProxy.address);
-
-      let members = await proxyFederationV2.methods.getMembers().call();
-      assert.equal(members.length, this.members.length);
-      assert.equal(members[0], this.members[0]);
-      assert.equal(members[1], this.members[1]);
-
-      let owner = await proxyFederationV2.methods.owner().call();
-      assert.equal(owner, deployer);
       let result = await proxyFederationV2.methods.version().call();
       assert.equal(result, 'v2');
 
-      const federation = await Federation.new();
-      await proxyAdmin.upgrade(federationProxy.address, federation.address)
-      const proxyFederation = new web3.eth.Contract(federation.abi, federationProxy.address);
+      await this.proxyAdmin.upgrade(federationProxy.address, this.federation.address)
+      const proxyFederation = new web3.eth.Contract(this.federation.abi, federationProxy.address);
+
       result = await proxyFederation.methods.version().call();
       assert.equal(result, 'v3');
+    });
+
+    it('should maintain the same contract owner from Federation v2', async function () {
+      const initData = await this.federationV2.contract.methods.initialize([federator1], 1, bridge, deployer).encodeABI();
+      const federationProxy = await FederationProxy.new(this.federationV2.address, this.proxyAdmin.address, initData);
+      const proxyFederationV2 = new web3.eth.Contract(this.federationV2.abi, federationProxy.address);
+
+      let ownerV2 = await proxyFederationV2.methods.owner().call();
+      assert.equal(ownerV2, deployer);
+
+      await this.proxyAdmin.upgrade(federationProxy.address, this.federation.address)
+      const proxyFederation = new web3.eth.Contract(this.federation.abi, federationProxy.address);
+
+      let ownerV3 = await proxyFederation.methods.owner().call();
+      assert.equal(ownerV2, ownerV3);
+    });
+
+    it('should not have setNFTBridge method before upgrade', async function () {
+      const initData = await this.federationV2.contract.methods.initialize([federator1], 1, bridge, deployer).encodeABI();
+      const federationProxy = await FederationProxy.new(this.federationV2.address, this.proxyAdmin.address, initData);
+      const proxyFederationV2 = new web3.eth.Contract(this.federationV2.abi, federationProxy.address);
+
+      assert.equal(proxyFederationV2.methods.setNFTBridge, undefined);
+    });
+
+    it('should have setNFTBridge method after update', async function () {
+      const initData = await this.federationV2.contract.methods.initialize([federator1], 1, bridge, deployer).encodeABI();
+      const federationProxy = await FederationProxy.new(this.federationV2.address, this.proxyAdmin.address, initData);
+
+      await this.proxyAdmin.upgrade(federationProxy.address, this.federation.address)
+      const proxyFederation = new web3.eth.Contract(this.federation.abi, federationProxy.address);
+
+      await proxyFederation.methods.setNFTBridge(this.nftBridge.address).send({from: deployer});
+      const nftBridgeSet = await proxyFederation.methods.bridgeNFT().call();
+      assert.equal(nftBridgeSet, this.nftBridge.address);
+    });
+
+    it('should maintain the members from the Federation v2', async function () {
+      const initialMembers  = [federator1, federator2];
+      const initData = await this.federationV2.contract.methods.initialize(initialMembers, 1, bridge, deployer).encodeABI();
+      const federationProxy = await FederationProxy.new(this.federationV2.address, this.proxyAdmin.address, initData);
+      const proxyFederationV2 = new web3.eth.Contract(this.federationV2.abi, federationProxy.address);
+
+      let members = await proxyFederationV2.methods.getMembers().call();
+      assert.equal(members.length, initialMembers.length);
+      assert.equal(members[0], initialMembers[0]);
+      assert.equal(members[1], initialMembers[1]);
+
+
+      await this.proxyAdmin.upgrade(federationProxy.address, this.federation.address)
+      const proxyFederation = new web3.eth.Contract(this.federation.abi, federationProxy.address);
 
       members = await proxyFederation.methods.getMembers().call();
-      assert.equal(members.length, this.members.length);
-      assert.equal(members[0], this.members[0]);
-      assert.equal(members[1], this.members[1]);
+      assert.equal(members.length, initialMembers.length);
+      assert.equal(members[0], initialMembers[0]);
+      assert.equal(members[1], initialMembers[1]);
     });
   });
 });
-6


### PR DESCRIPTION
### Add Tests to federation upgrade V2 to the federation

### Description

- Add tests checking the NFTBridge methods and owner

### How to Test

- Enter into the bridge directory and the tests for the federation test

#### Case 1

1. Go to bridge directory
```shell
$~ cd bridge
```
2. Run all the tests for the Federation upgrade
```shell
$~ npx hardhat test test/nftbridge/FederationV2_to_federation_test.js
```
__Expected Result__
- It should pass the test
![image](https://user-images.githubusercontent.com/17556614/131671206-cd72bb35-6b23-4289-8802-211445512f03.png)
### Checklist

#### Bridge Directory `cd bridge`
- [x] Lint is clean `npm run lint`
- [x] Test is passing `npm run test`
- [x] Contracts are compiling `npm run compile`

#### Federator Directory `cd federator`
- [x] Lint is clean `npm run lint`
- [x] Test is passing `npm run test`
- [x] Typescript is compiling `npm run build`