### PR TITLE
Add multichain logic to NFT Bridge

### DIFF
--- a/bridge/abi/NFTBridge.json
+++ b/bridge/abi/NFTBridge.json
@@ -43,6 +43,18 @@
         "internalType": "uint256",
         "name": "_logIndex",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_destinationChainId",
+        "type": "uint256"
       }
     ],
     "name": "AcceptedNFTCrossTransfer",
@@ -111,6 +123,18 @@
         "internalType": "address",
         "name": "_receiver",
         "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_destinationChainId",
+        "type": "uint256"
       }
     ],
     "name": "ClaimedNFTToken",
@@ -217,6 +241,12 @@
         "internalType": "string",
         "name": "_newSymbol",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "originChainId",
+        "type": "uint256"
       }
     ],
     "name": "NewSideNFTToken",
@@ -381,6 +411,16 @@
         "internalType": "uint32",
         "name": "_logIndex",
         "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_destinationChainId",
+        "type": "uint256"
       }
     ],
     "name": "acceptTransfer",
@@ -491,6 +531,11 @@
             "internalType": "uint32",
             "name": "logIndex",
             "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "originChainId",
+            "type": "uint256"
           }
         ],
         "internalType": "struct INFTBridge.NFTClaimData",
@@ -541,6 +586,11 @@
             "internalType": "uint32",
             "name": "logIndex",
             "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "originChainId",
+            "type": "uint256"
           }
         ],
         "internalType": "struct INFTBridge.NFTClaimData",
@@ -598,6 +648,11 @@
         "internalType": "string",
         "name": "_contractURI",
         "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "originChainId",
+        "type": "uint256"
       }
     ],
     "name": "createSideNFTToken",
@@ -626,6 +681,61 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sideToken",
+        "type": "address"
+      }
+    ],
+    "name": "getOriginalTokenBySideToken",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "nftAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "originChainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct INFTBridge.OriginalNft",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originalToken",
+        "type": "address"
+      }
+    ],
+    "name": "getSideTokenByOriginalToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -691,6 +801,16 @@
         "internalType": "uint32",
         "name": "_logIndex",
         "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_destinationChainId",
+        "type": "uint256"
       }
     ],
     "name": "getTransactionDataHash",
@@ -798,12 +918,41 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originalToken",
+        "type": "address"
+      }
+    ],
+    "name": "isAddressFromCrossedOriginalToken",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "addressHasCrossed",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
         "internalType": "address",
         "name": "",
         "type": "address"
       }
     ],
-    "name": "isAddressFromCrossedOriginalToken",
+    "name": "isAddressFromCrossedOriginalTokenByChain",
     "outputs": [
       {
         "internalType": "bool",
@@ -901,12 +1050,17 @@
         "type": "address"
       }
     ],
-    "name": "originalTokenAddressBySideTokenAddress",
+    "name": "originalTokenBySideToken",
     "outputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "nftAddress",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "originChainId",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -961,6 +1115,11 @@
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "destinationChainId",
+        "type": "uint256"
       }
     ],
     "name": "receiveTokensTo",
@@ -986,11 +1145,87 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originalToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "addressHasCrossed",
+        "type": "bool"
+      }
+    ],
+    "name": "setAddressFromCrossedOriginalToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
       }
     ],
     "name": "setFixedFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sideToken",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "nftAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "originChainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct INFTBridge.OriginalNft",
+        "name": "originalToken",
+        "type": "tuple"
+      }
+    ],
+    "name": "setOriginalTokenBySideToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originalToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "sideToken",
+        "type": "address"
+      }
+    ],
+    "name": "setSideTokenByOriginalToken",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1011,12 +1246,17 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
         "internalType": "address",
         "name": "",
         "type": "address"
       }
     ],
-    "name": "sideTokenAddressByOriginalTokenAddress",
+    "name": "sideTokenByOriginalTokenByChain",
     "outputs": [
       {
         "internalType": "address",

--- a/bridge/abi/NFTBridge.json
+++ b/bridge/abi/NFTBridge.json
@@ -190,6 +190,18 @@
         "internalType": "string",
         "name": "_tokenURI",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_destinationChainId",
+        "type": "uint256"
       }
     ],
     "name": "Cross",

--- a/bridge/contracts/Bridge/Bridge.sol
+++ b/bridge/contracts/Bridge/Bridge.sol
@@ -41,7 +41,7 @@ contract Bridge is Initializable, IBridge, IERC777Recipient, UpgradablePausable,
 	address internal federation;
 	uint256 internal feePercentage;
 	string public symbolPrefix;
-	// replaces uint256 internal _depprecatedLastDay;
+	// domainSeparator replaces uint256 internal _depprecatedLastDay;
 	bytes32 public domainSeparator;
 	uint256 internal _deprecatedSpentToday;
 

--- a/bridge/contracts/Federation/Federation.sol
+++ b/bridge/contracts/Federation/Federation.sol
@@ -281,8 +281,8 @@ contract Federation is Initializable, UpgradableOwnable, IFederation {
         blockHash,
         transactionHash,
         logIndex,
-				originChainId,
-				destinationChainId
+	originChainId,
+	destinationChainId
       );
       return;
     }

--- a/bridge/contracts/Federation/Federation.sol
+++ b/bridge/contracts/Federation/Federation.sol
@@ -256,7 +256,6 @@ contract Federation is Initializable, UpgradableOwnable, IFederation {
 				originChainId,
 				destinationChainId
 			);
-			return;
 		}
 	}
 
@@ -281,7 +280,9 @@ contract Federation is Initializable, UpgradableOwnable, IFederation {
         value,
         blockHash,
         transactionHash,
-        logIndex
+        logIndex,
+				originChainId,
+				destinationChainId
       );
       return;
     }

--- a/bridge/contracts/Federation/FederationV3.sol
+++ b/bridge/contracts/Federation/FederationV3.sol
@@ -224,8 +224,10 @@ contract FederationV3 is Initializable, UpgradableOwnable, IFederationV3 {
         value,
         blockHash,
         transactionHash,
-        logIndex
-      );
+        logIndex,
+        block.chainid,
+        block.chainid
+      ); // TODO: remove the v3
       return;
     }
 

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -93,7 +93,7 @@ interface INFTBridge {
     bytes32 _blockHash,
     uint256 _logIndex,
     uint256 _originChainId,
-		uint256	_destinationChainId
+	uint256	_destinationChainId
   );
   event FixedFeeNFTChanged(uint256 _amount);
   event ClaimedNFTToken(

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -74,7 +74,9 @@ interface INFTBridge {
     bytes _userData,
     uint256 _totalSupply,
     uint256 _tokenId,
-    string _tokenURI
+    string _tokenURI,
+    uint256 _originChainId,
+		uint256 _destinationChainId
   );
   event NewSideNFTToken(
     address indexed _newSideNFTTokenAddress,

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -76,7 +76,7 @@ interface INFTBridge {
     uint256 _tokenId,
     string _tokenURI,
     uint256 _originChainId,
-		uint256 _destinationChainId
+	uint256 _destinationChainId
   );
   event NewSideNFTToken(
     address indexed _newSideNFTTokenAddress,

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 pragma abicoder v2;
 
 interface INFTBridge {
+
   struct NFTClaimData {
     address payable to;
     address from;
@@ -12,7 +13,13 @@ interface INFTBridge {
     bytes32 blockHash;
     bytes32 transactionHash;
     uint32 logIndex;
+    uint256 originChainId;
   }
+
+	struct OriginalNft {
+		address nftAddress;
+		uint256 originChainId;
+	}
 
   function version() external pure returns (string memory);
 
@@ -21,7 +28,8 @@ interface INFTBridge {
   function receiveTokensTo(
     address tokenAddress,
     address to,
-    uint256 tokenId
+    uint256 tokenId,
+    uint256 destinationChainId
   ) external payable;
 
   /**
@@ -34,7 +42,9 @@ interface INFTBridge {
     uint256 _tokenId,
     bytes32 _blockHash,
     bytes32 _transactionHash,
-    uint32 _logIndex
+    uint32 _logIndex,
+    uint256 _originChainId,
+		uint256	_destinationChainId
   ) external;
 
   /**
@@ -51,7 +61,9 @@ interface INFTBridge {
     address _tokenAddress,
     bytes32 _blockHash,
     bytes32 _transactionHash,
-    uint32 _logIndex
+    uint32 _logIndex,
+    uint256 _originChainId,
+		uint256	_destinationChainId
   ) external returns (bytes32);
 
   event Cross(
@@ -67,7 +79,8 @@ interface INFTBridge {
   event NewSideNFTToken(
     address indexed _newSideNFTTokenAddress,
     address indexed _originalTokenAddress,
-    string _newSymbol
+    string _newSymbol,
+    uint256 originChainId
   );
   event AcceptedNFTCrossTransfer(
     bytes32 indexed _transactionHash,
@@ -76,7 +89,9 @@ interface INFTBridge {
     address _from,
     uint256 _tokenId,
     bytes32 _blockHash,
-    uint256 _logIndex
+    uint256 _logIndex,
+    uint256 _originChainId,
+		uint256	_destinationChainId
   );
   event FixedFeeNFTChanged(uint256 _amount);
   event ClaimedNFTToken(
@@ -87,6 +102,8 @@ interface INFTBridge {
     uint256 _tokenId,
     bytes32 _blockHash,
     uint256 _logIndex,
-    address _receiver
+    address _receiver,
+    uint256 _originChainId,
+		uint256	_destinationChainId
   );
 }

--- a/bridge/contracts/nftbridge/INFTBridge.sol
+++ b/bridge/contracts/nftbridge/INFTBridge.sol
@@ -44,7 +44,7 @@ interface INFTBridge {
     bytes32 _transactionHash,
     uint32 _logIndex,
     uint256 _originChainId,
-		uint256	_destinationChainId
+	uint256	_destinationChainId
   ) external;
 
   /**
@@ -106,6 +106,6 @@ interface INFTBridge {
     uint256 _logIndex,
     address _receiver,
     uint256 _originChainId,
-		uint256	_destinationChainId
+	uint256	_destinationChainId
   );
 }

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -105,7 +105,7 @@ contract NFTBridge is
     bytes32 _transactionHash,
     uint32 _logIndex,
     uint256 _originChainId,
-		uint256	_destinationChainId
+	uint256	_destinationChainId
   ) external whenNotPaused nonReentrant override {
     require(_msgSender() == federation, "NFTBridge: Not Federation");
     require(
@@ -131,7 +131,7 @@ contract NFTBridge is
       _transactionHash,
       _logIndex,
       _originChainId,
-		  _destinationChainId
+	_destinationChainId
     );
 
     // Do not remove, claimed will also have transactions previously processed using older bridge versions
@@ -149,7 +149,7 @@ contract NFTBridge is
       _blockHash,
       _logIndex,
       _originChainId,
-		  _destinationChainId
+	_destinationChainId
     );
   }
 
@@ -356,7 +356,7 @@ contract NFTBridge is
     bytes32 _transactionHash,
     uint32 _logIndex,
     uint256 _originChainId,
-		uint256	_destinationChainId
+	uint256	_destinationChainId
   ) public pure override returns (bytes32) {
     return keccak256(
       abi.encodePacked(

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -326,7 +326,9 @@ contract NFTBridge is
         userData,
         enumerable.totalSupply(),
         tokenId,
-        tokenURI
+        tokenURI,
+        block.chainid,
+				destinationChainId
       );
       return;
     }
@@ -339,7 +341,9 @@ contract NFTBridge is
       userData,
       enumerable.totalSupply(),
       tokenId,
-      tokenURI
+      tokenURI,
+      block.chainid,
+      destinationChainId
     );
   }
 

--- a/bridge/contracts/nftbridge/NFTBridge.sol
+++ b/bridge/contracts/nftbridge/NFTBridge.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 pragma abicoder v2;
 
+
 // Import base Initializable contract
 import "../zeppelin/upgradable/Initializable.sol";
 // Import interface and library from OpenZeppelin contracts
@@ -51,10 +52,11 @@ contract NFTBridge is
   uint256 internal fixedFee;
   string public symbolPrefix;
 
-  mapping(address => address) public sideTokenAddressByOriginalTokenAddress;
-  mapping(address => address) public originalTokenAddressBySideTokenAddress;
-  mapping(address => bool) public isAddressFromCrossedOriginalToken; // address => returns true if it's an original token address crossed previously (whether it comes from main or side chain)
+  mapping(uint256 => mapping(address => address)) public sideTokenByOriginalTokenByChain;
+  mapping(address => OriginalNft) public originalTokenBySideToken;
+  mapping(uint256 => mapping(address => bool)) public isAddressFromCrossedOriginalTokenByChain; // uint256 => address => returns true if it's an original token address crossed previously (whether it comes from main or side chain)
   mapping(bytes32 => bool) public claimed; // transactionDataHash => true // previously named processed
+
   IAllowTokens public allowTokens;
   ISideNFTTokenFactory public sideTokenFactory;
   bool public isUpgrading;
@@ -101,12 +103,14 @@ contract NFTBridge is
     uint256 _tokenId,
     bytes32 _blockHash,
     bytes32 _transactionHash,
-    uint32 _logIndex
+    uint32 _logIndex,
+    uint256 _originChainId,
+		uint256	_destinationChainId
   ) external whenNotPaused nonReentrant override {
     require(_msgSender() == federation, "NFTBridge: Not Federation");
     require(
-      isAddressFromCrossedOriginalToken[_tokenAddress] ||
-      sideTokenAddressByOriginalTokenAddress[_tokenAddress] != NULL_ADDRESS,
+      isAddressFromCrossedOriginalToken(_originChainId, _tokenAddress) ||
+      getSideTokenByOriginalToken(_originChainId, _tokenAddress) != NULL_ADDRESS,
       "NFTBridge: Unknown token"
     );
     require(_to != NULL_ADDRESS, "NFTBridge: Null To");
@@ -125,11 +129,13 @@ contract NFTBridge is
       _tokenAddress,
       _blockHash,
       _transactionHash,
-      _logIndex
+      _logIndex,
+      _originChainId,
+		  _destinationChainId
     );
+
     // Do not remove, claimed will also have transactions previously processed using older bridge versions
     require(!claimed[_transactionDataHash], "NFTBridge: Already claimed");
-
     transactionDataHashes[_transactionHash] = _transactionDataHash;
 //    tokenAddressByTransactionHash[_transactionHash] = _tokenAddress;
 //    senderAddresses[_transactionHash] = _from;
@@ -141,8 +147,34 @@ contract NFTBridge is
       _from,
       _tokenId,
       _blockHash,
-      _logIndex
+      _logIndex,
+      _originChainId,
+		  _destinationChainId
     );
+  }
+
+  function getSideTokenByOriginalToken(uint256 chainId, address originalToken) public view returns(address) {
+    return sideTokenByOriginalTokenByChain[chainId][originalToken];
+  }
+
+  function setSideTokenByOriginalToken(uint256 chainId, address originalToken, address sideToken) public {
+    sideTokenByOriginalTokenByChain[chainId][originalToken] = sideToken;
+  }
+
+  function getOriginalTokenBySideToken(address sideToken) public view returns(OriginalNft memory) {
+    return originalTokenBySideToken[sideToken];
+  }
+
+  function setOriginalTokenBySideToken(address sideToken, OriginalNft memory originalToken) public {
+    originalTokenBySideToken[sideToken] = originalToken;
+  }
+
+  function isAddressFromCrossedOriginalToken(uint256 chainId, address originalToken) public view returns(bool addressHasCrossed) {
+    return isAddressFromCrossedOriginalTokenByChain[chainId][originalToken];
+  }
+
+  function setAddressFromCrossedOriginalToken(uint256 chainId, address originalToken, bool addressHasCrossed) public {
+    isAddressFromCrossedOriginalTokenByChain[chainId][originalToken] = addressHasCrossed;
   }
 
   function createSideNFTToken(
@@ -150,19 +182,25 @@ contract NFTBridge is
     string calldata _originalTokenSymbol,
     string calldata _originalTokenName,
     string calldata _baseURI,
-    string calldata _contractURI
+    string calldata _contractURI,
+    uint256 originChainId
   ) external onlyOwner {
     require(_originalTokenAddress != NULL_ADDRESS, "NFTBridge: Null original token address");
-    address sideTokenAddress = sideTokenAddressByOriginalTokenAddress[_originalTokenAddress];
-    require(sideTokenAddress == NULL_ADDRESS, "NFTBridge: Side token already exists");
+
+    require(getSideTokenByOriginalToken(originChainId, _originalTokenAddress) == NULL_ADDRESS, "NFTBridge: Side token already exists");
     string memory sideTokenSymbol = string(abi.encodePacked(symbolPrefix, _originalTokenSymbol));
 
     // Create side token
-    sideTokenAddress = sideTokenFactory.createSideNFTToken(_originalTokenName, sideTokenSymbol, _baseURI, _contractURI);
+    address sideTokenAddress = sideTokenFactory.createSideNFTToken(_originalTokenName, sideTokenSymbol, _baseURI, _contractURI);
 
-    sideTokenAddressByOriginalTokenAddress[_originalTokenAddress] = sideTokenAddress;
-    originalTokenAddressBySideTokenAddress[sideTokenAddress] = _originalTokenAddress;
-    emit NewSideNFTToken(sideTokenAddress, _originalTokenAddress, sideTokenSymbol);
+    setSideTokenByOriginalToken(originChainId, _originalTokenAddress, sideTokenAddress);
+
+    OriginalNft memory originalNft;
+    originalNft.originChainId = originChainId;
+    originalNft.nftAddress = _originalTokenAddress;
+    setOriginalTokenBySideToken(sideTokenAddress, originalNft);
+
+    emit NewSideNFTToken(sideTokenAddress, _originalTokenAddress, sideTokenSymbol, originChainId);
   }
 
   function claim(NFTClaimData calldata _claimData) external override {
@@ -188,8 +226,12 @@ contract NFTBridge is
       tokenAddress,
       _claimData.blockHash,
       _claimData.transactionHash,
-      _claimData.logIndex
+      _claimData.logIndex,
+      _claimData.originChainId,
+      block.chainid
     );
+
+
     require(
       transactionDataHashes[_claimData.transactionHash] == transactionDataHash,
       "NFTBridge: Wrong txDataHash"
@@ -197,11 +239,10 @@ contract NFTBridge is
     require(!claimed[transactionDataHash], "NFTBridge: Already claimed");
 
     claimed[transactionDataHash] = true;
-    bool isClaimBeingRequestedInMainChain = isAddressFromCrossedOriginalToken[tokenAddress];
-    if (isClaimBeingRequestedInMainChain) {
+    if (isAddressFromCrossedOriginalToken(_claimData.originChainId, tokenAddress)) {
       IERC721(tokenAddress).safeTransferFrom(address(this), _receiver, tokenId);
     } else {
-      address sideTokenAddress = sideTokenAddressByOriginalTokenAddress[tokenAddress];
+      address sideTokenAddress = getSideTokenByOriginalToken(_claimData.originChainId, tokenAddress);
       ISideNFTToken(sideTokenAddress).mint(_receiver, tokenId);
     }
 
@@ -213,7 +254,9 @@ contract NFTBridge is
       _claimData.tokenId,
       _claimData.blockHash,
       _claimData.logIndex,
-      _receiver
+      _receiver,
+      _claimData.originChainId,
+      block.chainid
     );
   }
 
@@ -233,14 +276,15 @@ contract NFTBridge is
   function receiveTokensTo(
     address tokenAddress,
     address to,
-    uint256 tokenId
+    uint256 tokenId,
+    uint256 destinationChainId
   ) public payable override {
     address tokenCreator = getTokenCreator(tokenAddress, tokenId);
     address payable sender = _msgSender();
     // Transfer the tokens on IERC721, they should be already Approved for the bridge Address to use them
     IERC721(tokenAddress).transferFrom(sender, address(this), tokenId);
 
-    crossTokens(tokenAddress, to, tokenCreator, "", tokenId);
+    crossTokens(tokenAddress, to, tokenCreator, "", tokenId, destinationChainId);
 
     if (fixedFee == 0) {
       return;
@@ -261,22 +305,34 @@ contract NFTBridge is
     address to,
     address tokenCreator,
     bytes memory userData,
-    uint256 tokenId
+    uint256 tokenId,
+    uint256 destinationChainId
   ) internal whenNotUpgrading whenNotPaused nonReentrant {
-    isAddressFromCrossedOriginalToken[tokenAddress] = true;
+    require(block.chainid != destinationChainId, "NFTBridge: destination chain id equal current chain id");
+    setAddressFromCrossedOriginalToken(destinationChainId, tokenAddress, true);
 
     IERC721Enumerable enumerable = IERC721Enumerable(tokenAddress);
     IERC721Metadata metadataIERC = IERC721Metadata(tokenAddress);
     string memory tokenURI = metadataIERC.tokenURI(tokenId);
 
-    address originalTokenAddress = tokenAddress;
-    if (originalTokenAddressBySideTokenAddress[tokenAddress] != NULL_ADDRESS) {
-      originalTokenAddress = originalTokenAddressBySideTokenAddress[tokenAddress];
+    OriginalNft memory originalToken = getOriginalTokenBySideToken(tokenAddress);
+    if (originalToken.nftAddress != NULL_ADDRESS) {
       ERC721Burnable(tokenAddress).burn(tokenId);
+      emit Cross(
+        originalToken.nftAddress,
+        _msgSender(),
+        to,
+        tokenCreator,
+        userData,
+        enumerable.totalSupply(),
+        tokenId,
+        tokenURI
+      );
+      return;
     }
 
     emit Cross(
-      originalTokenAddress,
+      tokenAddress,
       _msgSender(),
       to,
       tokenCreator,
@@ -294,7 +350,9 @@ contract NFTBridge is
     address _tokenAddress,
     bytes32 _blockHash,
     bytes32 _transactionHash,
-    uint32 _logIndex
+    uint32 _logIndex,
+    uint256 _originChainId,
+		uint256	_destinationChainId
   ) public pure override returns (bytes32) {
     return keccak256(
       abi.encodePacked(
@@ -304,7 +362,9 @@ contract NFTBridge is
         _from,
         _tokenId,
         _tokenAddress,
-        _logIndex
+        _logIndex,
+        _originChainId,
+        _destinationChainId
       )
     );
   }

--- a/bridge/hardhat/script/createSideNftToken.js
+++ b/bridge/hardhat/script/createSideNftToken.js
@@ -57,10 +57,10 @@ async function main() {
     });
     console.log("Transaction worked", receipt.transactionHash);
 
-    const sideTokenAddress = await nftBridge.methods.sideTokenAddressByOriginalTokenAddress(nftToken.originalTokenAddress).call({from: MultiSigWallet.address});
+    const sideTokenAddress = await nftBridge.methods.getSideTokenByOriginalToken(nftToken.originalTokenAddress).call({from: MultiSigWallet.address});
     console.log("Token address Mapped for", nftToken.name, ":", sideTokenAddress);
-    const originalTokenAddress = await nftBridge.methods.originalTokenAddressBySideTokenAddress(nftToken.originalTokenAddress).call({from: MultiSigWallet.address});
-    console.log("Token address Original for", nftToken.name, ":", originalTokenAddress);
+    const originalToken = await nftBridge.methods.getOriginalTokenBySideToken(nftToken.originalTokenAddress).call({from: MultiSigWallet.address});
+    console.log("Token address Original for", nftToken.name, ":", originalToken);
   }
 
   console.log("finish");

--- a/bridge/test/Federation_test.js
+++ b/bridge/test/Federation_test.js
@@ -1068,7 +1068,7 @@ contract('Federation', async function (accounts) {
                     blockHash,
                     transactionHash,
                     logIndex,
-                    chains.HARDHAT_TEST_NET_CHAIN_ID,
+                    chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                     chains.HARDHAT_TEST_NET_CHAIN_ID,
                 );
                 let transactionCount = await this.federators.getTransactionCount(transactionId);
@@ -1083,7 +1083,7 @@ contract('Federation', async function (accounts) {
                     transactionHash,
                     logIndex,
                     utils.tokenType.COIN,
-                    chains.HARDHAT_TEST_NET_CHAIN_ID,
+                    chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                     chains.HARDHAT_TEST_NET_CHAIN_ID,
                     {from: federator1}
                 );
@@ -1186,6 +1186,7 @@ contract('Federation', async function (accounts) {
                   this.NFTtoken.address,
                   anotherAccount,
                   tokenId,
+                  chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                   { from: deployer }
                 );
                 utils.checkRcpt(receipt);
@@ -1198,8 +1199,8 @@ contract('Federation', async function (accounts) {
                   blockHash,
                   transactionHash,
                   logIndex,
+                  chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                   chains.HARDHAT_TEST_NET_CHAIN_ID,
-                  chains.HARDHAT_TEST_NET_CHAIN_ID
                 );
                 let transactionCount = await this.federators.getTransactionCount(transactionId);
                 assert.equal(transactionCount, 0);
@@ -1213,7 +1214,7 @@ contract('Federation', async function (accounts) {
                     transactionHash,
                     logIndex,
                     utils.tokenType.NFT,
-                    chains.HARDHAT_TEST_NET_CHAIN_ID,
+                    chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                     chains.HARDHAT_TEST_NET_CHAIN_ID,
                     { from: federator1 }
                 );
@@ -1243,7 +1244,7 @@ contract('Federation', async function (accounts) {
                   transactionHash,
                   logIndex,
                   utils.tokenType.NFT,
-                  chains.HARDHAT_TEST_NET_CHAIN_ID,
+                  chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                   chains.HARDHAT_TEST_NET_CHAIN_ID,
                   { from: federator2 }
                 );

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -241,7 +241,8 @@ contract("Bridge NFT", async function(accounts) {
           this.token.address,
           anAccount,
           defaultTokenId,
-          { from: tokenOwner }
+          chains.ETHEREUM_MAIN_NET_CHAIN_ID,
+          { from: tokenOwner },
         );
         utils.checkRcpt(receipt);
 
@@ -271,6 +272,7 @@ contract("Bridge NFT", async function(accounts) {
           this.token.address,
           anAccount,
           defaultTokenId,
+          chains.ETHEREUM_MAIN_NET_CHAIN_ID,
           { from: tokenOwner }
         );
         utils.checkRcpt(receipt);
@@ -300,6 +302,7 @@ contract("Bridge NFT", async function(accounts) {
           this.token.address,
           anAccount,
           defaultTokenId,
+          chains.ETHEREUM_MAIN_NET_CHAIN_ID,
           { from: tokenOwner }
         );
         utils.checkRcpt(receipt);
@@ -332,6 +335,7 @@ contract("Bridge NFT", async function(accounts) {
           this.token.address,
           anAccount,
           defaultTokenId,
+          chains.ETHEREUM_MAIN_NET_CHAIN_ID,
           { from: tokenOwner }
         );
         utils.checkRcpt(receipt);
@@ -372,6 +376,7 @@ contract("Bridge NFT", async function(accounts) {
             this.token.address,
             anAccount,
             defaultTokenId,
+            chains.ETHEREUM_MAIN_NET_CHAIN_ID,
             {
               from: tokenOwner,
               value: fixedFee,
@@ -414,6 +419,7 @@ contract("Bridge NFT", async function(accounts) {
             this.token.address,
             anAccount,
             defaultTokenId,
+            chains.ETHEREUM_MAIN_NET_CHAIN_ID,
             {
               from: tokenOwner,
               value: fixedFee.add(new BN("10")),
@@ -453,6 +459,7 @@ contract("Bridge NFT", async function(accounts) {
             this.token.address,
             anAccount,
             defaultTokenId,
+            chains.ETHEREUM_MAIN_NET_CHAIN_ID,
             {
               from: tokenOwner
             }
@@ -480,6 +487,7 @@ contract("Bridge NFT", async function(accounts) {
               this.token.address,
               anAccount,
               defaultTokenId,
+              chains.ETHEREUM_MAIN_NET_CHAIN_ID,
               {
                 from: tokenOwner,
                 value: fixedFee,
@@ -503,6 +511,7 @@ contract("Bridge NFT", async function(accounts) {
               this.token.address,
               anAccount,
               defaultTokenId,
+              chains.ETHEREUM_MAIN_NET_CHAIN_ID,
               {
                 from: tokenOwner,
                 value: fixedFee.sub(bigNumberOne),
@@ -531,7 +540,7 @@ contract("Bridge NFT", async function(accounts) {
 
       it("creates token correctly and emits expected event when inputs are correct", async function() {
         let receipt = await this.NFTBridge.createSideNFTToken(
-            tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
+            tokenAddress, symbol, name, baseURI, contractURI, chains.HARDHAT_TEST_NET_CHAIN_ID, {from: bridgeManager}
         );
 
         utils.checkRcpt(receipt);
@@ -553,21 +562,22 @@ contract("Bridge NFT", async function(accounts) {
         const newSideNFTTokenBaseURI = await newSideNFTToken.baseURI();
         assert.equal(baseURI, newSideNFTTokenBaseURI);
 
-        let sideTokenAddressMappedByBridge = await this.NFTBridge.sideTokenAddressByOriginalTokenAddress(
+        let sideTokenAddressMappedByBridge = await this.NFTBridge.getSideTokenByOriginalToken(
+          chains.HARDHAT_TEST_NET_CHAIN_ID,
           tokenAddress
         );
         assert.equal(newSideNFTTokenAddress, sideTokenAddressMappedByBridge);
 
-        let tokenAddressMappedByBridge = await this.NFTBridge.originalTokenAddressBySideTokenAddress(
+        let originalTokenAddressMappedByBridge = await this.NFTBridge.getOriginalTokenBySideToken(
           newSideNFTTokenAddress
         );
-        assert.equal(tokenAddress, tokenAddressMappedByBridge);
+        assert.equal(tokenAddress, originalTokenAddressMappedByBridge.nftAddress);
       });
 
       it("fails to create side NFT token if the original token address is a null address", async function() {
         await truffleAssert.fails(
             this.NFTBridge.createSideNFTToken(
-                utils.NULL_ADDRESS, symbol, name, baseURI, contractURI, {from: bridgeManager}
+                utils.NULL_ADDRESS, symbol, name, baseURI, contractURI, chains.HARDHAT_TEST_NET_CHAIN_ID, {from: bridgeManager}
             ),
             truffleAssert.ErrorType.REVERT,
             "Bridge: Null original token address"
@@ -576,14 +586,14 @@ contract("Bridge NFT", async function(accounts) {
 
       it("fails to create side NFT token if side token address already exists", async function() {
         let receipt = await this.NFTBridge.createSideNFTToken(
-          tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
+          tokenAddress, symbol, name, baseURI, contractURI, chains.HARDHAT_TEST_NET_CHAIN_ID, {from: bridgeManager}
         );
 
         truffleAssert.eventEmitted(receipt, newSideNFTTokenEventType);
 
         await truffleAssert.fails(
           this.NFTBridge.createSideNFTToken(
-            tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
+            tokenAddress, symbol, name, baseURI, contractURI, chains.HARDHAT_TEST_NET_CHAIN_ID, {from: bridgeManager}
           ),
           truffleAssert.ErrorType.REVERT,
           "Bridge: Side token already exists"
@@ -593,7 +603,7 @@ contract("Bridge NFT", async function(accounts) {
       it("fails to create side NFT token if transaction sender is not bridge manager", async function() {
         await truffleAssert.fails(
           this.NFTBridge.createSideNFTToken(
-            tokenAddress, symbol, name, baseURI, contractURI, {from: anAccount}
+            tokenAddress, symbol, name, baseURI, contractURI, chains.HARDHAT_TEST_NET_CHAIN_ID, {from: anAccount}
           ),
           truffleAssert.ErrorType.REVERT,
           "Ownable: caller is not the owner"
@@ -619,24 +629,26 @@ contract("Bridge NFT", async function(accounts) {
         contractURI = await this.token.contractURI();
         tokenAddress = this.token.address;
         let receipt = await this.NFTBridge.createSideNFTToken(
-            tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
+          tokenAddress, symbol, name, baseURI, contractURI, chains.ETHEREUM_MAIN_NET_CHAIN_ID, {from: bridgeManager}
         );
         utils.checkRcpt(receipt);
       });
 
       it("accepts transfer and emits event correctly", async function () {
-        await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash, logIndex);
+        await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID);
       });
 
-      async function assertAcceptTransferSuccessfulResult(tokenAddress, tokenId, blockHash, transactionHash, logIndex) {
+      async function assertAcceptTransferSuccessfulResult(tokenAddress, tokenId, blockHash, transactionHash, logIndex, originChainId, destinationChainId) {
         const receipt = await this.NFTBridge.acceptTransfer(
             tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
+            originChainId, destinationChainId,
             {from: federation}
         );
         utils.checkRcpt(receipt);
 
         const expectedTransactionDataHash = await this.NFTBridge.getTransactionDataHash(
-            anotherAccount, anAccount, tokenId, tokenAddress, blockHash, transactionHash, logIndex
+            anotherAccount, anAccount, tokenId, tokenAddress, blockHash, transactionHash, logIndex,
+            originChainId, destinationChainId
         );
 
         let transactionDataHash = await this.NFTBridge.transactionDataHashes(transactionHash);
@@ -662,6 +674,7 @@ contract("Bridge NFT", async function(accounts) {
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
+                chains.HARDHAT_TEST_NET_CHAIN_ID, chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                 {from: anAccount}
             ),
             "NFTBridge: Not Federation"
@@ -673,6 +686,7 @@ contract("Bridge NFT", async function(accounts) {
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 unknownTokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
+                chains.HARDHAT_TEST_NET_CHAIN_ID, chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                 {from: federation}
             ),
             "NFTBridge: Unknown token"
@@ -683,6 +697,7 @@ contract("Bridge NFT", async function(accounts) {
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, utils.NULL_ADDRESS, tokenId, blockHash, transactionHash, logIndex,
+                chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID,
                 {from: federation}
             ),
             "NFTBridge: Null To"
@@ -693,6 +708,7 @@ contract("Bridge NFT", async function(accounts) {
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 tokenAddress, utils.NULL_ADDRESS, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
+                chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID,
                 {from: federation}
             ),
             "NFTBridge: Null From"
@@ -703,6 +719,7 @@ contract("Bridge NFT", async function(accounts) {
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, utils.NULL_HASH, transactionHash, logIndex,
+                chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID,
                 {from: federation}
             ),
             "NFTBridge: Null BlockHash"
@@ -713,6 +730,7 @@ contract("Bridge NFT", async function(accounts) {
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, utils.NULL_HASH, logIndex,
+                chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID,
                 {from: federation}
             ),
             "NFTBridge: Null TxHash"
@@ -720,10 +738,12 @@ contract("Bridge NFT", async function(accounts) {
       });
 
       it("throws an error when transaction was already accepted", async function () {
-        await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash, logIndex);
+        await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash,
+          logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID);
         await truffleAssert.fails(
             this.NFTBridge.acceptTransfer(
                 tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
+                chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID,
                 {from: federation}
             ),
             "NFTBridge: Already accepted"
@@ -752,7 +772,7 @@ contract("Bridge NFT", async function(accounts) {
 
         // Side NFT token contract is created.
         let receipt = await this.sideNFTBridge.createSideNFTToken(
-            tokenAddress, symbol, name, baseURI, contractURI, {from: bridgeManager}
+          tokenAddress, symbol, name, baseURI, contractURI, chains.ETHEREUM_MAIN_NET_CHAIN_ID, {from: bridgeManager}
         );
         utils.checkRcpt(receipt);
         truffleAssert.eventEmitted(
@@ -777,15 +797,18 @@ contract("Bridge NFT", async function(accounts) {
 
         // Lock token into bridge.
         receipt = await this.NFTBridge.receiveTokensTo(
-            this.token.address, anotherAccount, tokenId, {from: anAccount}
+            this.token.address, anotherAccount, tokenId, chains.ETHEREUM_MAIN_NET_CHAIN_ID, {from: anAccount}
         );
         utils.checkRcpt(receipt);
 
         // Simulate Federator calling Bridge to accept the transfer.
         receipt = await this.sideNFTBridge.acceptTransfer(
             tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
+            chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID,
             {from: federation}
         );
+        console.log("blockHash before", blockHash);
+        console.log("transactionHash before", transactionHash);
         utils.checkRcpt(receipt);
         truffleAssert.eventEmitted(receipt, acceptedNFTCrossTransferEventType);
       });
@@ -794,7 +817,7 @@ contract("Bridge NFT", async function(accounts) {
           async function () {
             await assertTokenIsLockedInBridge(this.NFTBridge.address, anotherAccount, this.token);
             await claimTokenFromBridgeEnsuringEventEmission(this.sideNFTBridge, anotherAccount, anAccount, tokenId,
-                tokenAddress, blockHash, transactionHash, logIndex);
+                tokenAddress, blockHash, transactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID);
             let sideToken = await IERC721.at(sideTokenAddress);
             await assertTokenHasBeenClaimed(this.sideNFTBridge.address, anotherAccount, sideToken);
 
@@ -802,7 +825,8 @@ contract("Bridge NFT", async function(accounts) {
                 this.sideNFTBridge.claim(
                     {
                       to: anotherAccount, from: anAccount, tokenId: tokenId, tokenAddress: tokenAddress,
-                      blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex
+                      blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex,
+                      originChainId: chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                     },
                     {from: anotherAccount}
                 ),
@@ -819,7 +843,7 @@ contract("Bridge NFT", async function(accounts) {
         const receipt = await this.sideNFTBridge.claimFallback(
           {
             to: anotherAccount, from: anAccount, tokenId: tokenId, tokenAddress: tokenAddress,
-            blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex
+            blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex, originChainId: chains.ETHEREUM_MAIN_NET_CHAIN_ID,
           },
           {from: anAccount}
         );
@@ -842,7 +866,7 @@ contract("Bridge NFT", async function(accounts) {
       it("should check if it was claimed successfully when calling hasBeenClaimed", async function () {
         await assertTokenIsLockedInBridge(this.NFTBridge.address, anotherAccount, this.token);
         await claimTokenFromBridgeEnsuringEventEmission(this.sideNFTBridge, anotherAccount, anAccount, tokenId,
-            tokenAddress, blockHash, transactionHash, logIndex);
+            tokenAddress, blockHash, transactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID);
         const result = await this.sideNFTBridge.hasBeenClaimed(transactionHash);
         assert(result, "The token should have been claimed");
       });
@@ -850,7 +874,7 @@ contract("Bridge NFT", async function(accounts) {
       it("should check if it has crossed when calling hasCrossed", async function () {
         await assertTokenIsLockedInBridge(this.NFTBridge.address, anotherAccount, this.token);
         await claimTokenFromBridgeEnsuringEventEmission(this.sideNFTBridge, anotherAccount, anAccount, tokenId,
-            tokenAddress, blockHash, transactionHash, logIndex);
+            tokenAddress, blockHash, transactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID);
         const result = await this.sideNFTBridge.hasCrossed(transactionHash);
         assert(result, "The token should have been crossed");
       });
@@ -867,11 +891,12 @@ contract("Bridge NFT", async function(accounts) {
       }
 
       async function claimTokenFromBridgeEnsuringEventEmission(bridge, to, from, tokenId, tokenAddress, blockHash,
-                                                                transactionHash, logIndex) {
+                                                                transactionHash, logIndex, originChainId) {
         const receipt = await bridge.claim(
             {
               to: to, from: from, tokenId: tokenId, tokenAddress: tokenAddress,
-              blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex
+              blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex,
+              originChainId: originChainId,
             },
             {from: to}
         );
@@ -911,7 +936,8 @@ contract("Bridge NFT", async function(accounts) {
             this.sideNFTBridge.claim(
                 {
                   to: anotherAccount, from: anAccount, tokenId: unexpectedTokenId, tokenAddress: tokenAddress,
-                  blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex
+                  blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex,
+                  originChainId: chains.ETHEREUM_MAIN_NET_CHAIN_ID,
                 },
                 {from: anotherAccount}
             ),
@@ -926,7 +952,7 @@ contract("Bridge NFT", async function(accounts) {
             // Side token is correctly claimed from side chain.
             await assertTokenIsLockedInBridge(this.NFTBridge.address, anotherAccount, this.token);
             await claimTokenFromBridgeEnsuringEventEmission(this.sideNFTBridge, anotherAccount, anAccount, tokenId,
-                tokenAddress, blockHash, transactionHash, logIndex);
+                tokenAddress, blockHash, transactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID);
             let sideToken = await IERC721.at(sideTokenAddress);
             await assertTokenHasBeenClaimed(this.sideNFTBridge.address, anotherAccount, sideToken);
 
@@ -937,7 +963,7 @@ contract("Bridge NFT", async function(accounts) {
 
             // Side token is burned.
             receipt = await this.sideNFTBridge.receiveTokensTo(
-                sideToken.address, anAccount, tokenId, {from: anotherAccount}
+                sideToken.address, anAccount, tokenId, chains.ETHEREUM_MAIN_NET_CHAIN_ID, {from: anotherAccount}
             );
             const expectedTotalSupplyAfterBurn = 0;
             utils.checkRcpt(receipt);
@@ -958,7 +984,7 @@ contract("Bridge NFT", async function(accounts) {
             const crossBackTransactionHash = utils.getRandomHash();
             receipt = await this.NFTBridge.acceptTransfer(
                 tokenAddress, anotherAccount, anAccount, tokenId, crossBackBlockHash, crossBackTransactionHash,
-                logIndex, {from: federation}
+                logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID, {from: federation}
             );
             utils.checkRcpt(receipt);
             truffleAssert.eventEmitted(receipt, acceptedNFTCrossTransferEventType);
@@ -966,7 +992,7 @@ contract("Bridge NFT", async function(accounts) {
 
             // Original token is correctly claimed from main chain.
             await claimTokenFromBridgeEnsuringEventEmission(this.NFTBridge, anAccount, anotherAccount, tokenId, tokenAddress,
-                crossBackBlockHash, crossBackTransactionHash, logIndex);
+                crossBackBlockHash, crossBackTransactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID);
             await assertTokenHasBeenClaimed(this.NFTBridge.address, anAccount, this.token);
           });
 

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -562,13 +562,13 @@ contract("Bridge NFT", async function(accounts) {
         const newSideNFTTokenBaseURI = await newSideNFTToken.baseURI();
         assert.equal(baseURI, newSideNFTTokenBaseURI);
 
-        let sideTokenAddressMappedByBridge = await this.NFTBridge.getSideTokenByOriginalToken(
+        const sideTokenAddressMappedByBridge = await this.NFTBridge.getSideTokenByOriginalToken(
           chains.HARDHAT_TEST_NET_CHAIN_ID,
           tokenAddress
         );
         assert.equal(newSideNFTTokenAddress, sideTokenAddressMappedByBridge);
 
-        let originalTokenAddressMappedByBridge = await this.NFTBridge.getOriginalTokenBySideToken(
+        const originalTokenAddressMappedByBridge = await this.NFTBridge.getOriginalTokenBySideToken(
           newSideNFTTokenAddress
         );
         assert.equal(tokenAddress, originalTokenAddressMappedByBridge.nftAddress);
@@ -635,25 +635,27 @@ contract("Bridge NFT", async function(accounts) {
       });
 
       it("accepts transfer and emits event correctly", async function () {
-        await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash, logIndex, chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID);
+        await assertAcceptTransferSuccessfulResult.call(this, tokenAddress, tokenId, blockHash, transactionHash, logIndex,
+          chains.ETHEREUM_MAIN_NET_CHAIN_ID, chains.HARDHAT_TEST_NET_CHAIN_ID);
       });
 
-      async function assertAcceptTransferSuccessfulResult(tokenAddress, tokenId, blockHash, transactionHash, logIndex, originChainId, destinationChainId) {
+      async function assertAcceptTransferSuccessfulResult(nftTokenAddress, nftTokenId, nftBlockHash, nftTransactionHash, nftLogIndex, originChainId, destinationChainId) {
         const receipt = await this.NFTBridge.acceptTransfer(
-            tokenAddress, anAccount, anotherAccount, tokenId, blockHash, transactionHash, logIndex,
-            originChainId, destinationChainId,
-            {from: federation}
+          nftTokenAddress, anAccount, anotherAccount, nftTokenId, nftBlockHash, nftTransactionHash, nftLogIndex,
+          originChainId, destinationChainId,
+          {from: federation}
         );
         utils.checkRcpt(receipt);
 
         const expectedTransactionDataHash = await this.NFTBridge.getTransactionDataHash(
-            anotherAccount, anAccount, tokenId, tokenAddress, blockHash, transactionHash, logIndex,
-            originChainId, destinationChainId
+          anotherAccount, anAccount, nftTokenId, nftTokenAddress, nftBlockHash, nftTransactionHash, nftLogIndex,
+          originChainId, destinationChainId
         );
 
-        let transactionDataHash = await this.NFTBridge.transactionDataHashes(transactionHash);
+        const transactionDataHash = await this.NFTBridge.transactionDataHashes(nftTransactionHash);
         assert.equal(expectedTransactionDataHash, transactionDataHash);
-        assertAcceptedTransferEventOccurrence(receipt, transactionHash, tokenAddress, tokenId, blockHash, logIndex);
+        assertAcceptedTransferEventOccurrence(receipt, nftTransactionHash, nftTokenAddress, nftTokenId,
+          nftBlockHash, nftLogIndex);
       }
 
       function assertAcceptedTransferEventOccurrence(receipt, transactionHash, tokenAddress, tokenId, blockHash, logIndex) {

--- a/bridge/test/nftbridge/NFTBridge_test.js
+++ b/bridge/test/nftbridge/NFTBridge_test.js
@@ -893,11 +893,11 @@ contract("Bridge NFT", async function(accounts) {
       }
 
       async function claimTokenFromBridgeEnsuringEventEmission(bridge, to, from, tokenId, tokenAddress, blockHash,
-                                                                transactionHash, logIndex, originChainId) {
+                                                                nftTransactionHash, nftLogIndex, originChainId) {
         const receipt = await bridge.claim(
             {
               to: to, from: from, tokenId: tokenId, tokenAddress: tokenAddress,
-              blockHash: blockHash, transactionHash: transactionHash, logIndex: logIndex,
+              blockHash: blockHash, transactionHash: nftTransactionHash, logIndex: nftLogIndex,
               originChainId: originChainId,
             },
             {from: to}
@@ -905,13 +905,13 @@ contract("Bridge NFT", async function(accounts) {
 
         truffleAssert.eventEmitted(receipt, claimedNFTTokenEventType, (event) => {
           return (
-              event._transactionHash === transactionHash &&
+              event._transactionHash === nftTransactionHash &&
               event._originalTokenAddress === tokenAddress &&
               event._to === to &&
               event._sender === from &&
               event._tokenId.eq(new BN(tokenId)) &&
               event._blockHash === blockHash &&
-              event._logIndex.eq(new BN(logIndex)) &&
+              event._logIndex.eq(new BN(nftLogIndex)) &&
               event._receiver === to
           );
         });

--- a/federator/integrationTest/nftIntegrationTest.js
+++ b/federator/integrationTest/nftIntegrationTest.js
@@ -110,10 +110,12 @@ async function runNFT({
   );
   logger.info("[NFT] Completed transfer from Mainchain to Sidechain");
 
+  const invertOriginFederators = destinationFederators;
+  const invertDestinationFederators = originFederators;
   logger.info("[NFT] Starting transfer from Sidechain to Mainchain");
   await transferNFT(
-    destinationFederators,
-    originFederators,
+    invertOriginFederators,
+    invertDestinationFederators,
     destinationConfig,
     SIDE_CHAIN_LOGGER_NAME,
     MAIN_CHAIN_LOGGER_NAME
@@ -320,7 +322,7 @@ async function getDestinationNFTTokenAddress({
     .call();
   if (destinationTokenAddress === utils.zeroAddress) {
     logger.info("Side NFT Token does not exist yet, creating it");
-    let bridgeAddress = await destinationNftBridgeContract.options.address;
+    const bridgeAddress = await destinationNftBridgeContract.options.address;
     const data = destinationNftBridgeContract.methods
       .createSideNFTToken(
         originAddress,

--- a/federator/integrationTest/nftIntegrationTest.js
+++ b/federator/integrationTest/nftIntegrationTest.js
@@ -1,267 +1,536 @@
-const Web3 = require('web3');
-const log4js = require('log4js');
+const Web3 = require("web3");
+const log4js = require("log4js");
 const web3Utils = Web3.utils;
-const config = require('../config/test.local.config.js');
-const logConfig = require('../config/log-config.json');
+const config = require("../config/test.local.config.js");
+const logConfig = require("../config/log-config.json");
 
-const abiMultiSig = require('../../bridge/abi/MultiSigWallet.json');
-const abiNFTBridge = require('../../bridge/abi/NFTBridge.json');
-const abiNFTERC721TestToken = require('../../bridge/abi/NFTERC721TestToken.json');
-const abiSideNFTToken = require('../../bridge/abi/SideNFTToken.json');
-const abiDecoder = require('abi-decoder');
-const abiAcceptedNFTCrossTransferEvent = abiNFTBridge.find(abi => abi.name === 'Cross');
+const abiMultiSig = require("../../bridge/abi/MultiSigWallet.json");
+const abiNFTBridge = require("../../bridge/abi/NFTBridge.json");
+const abiNFTERC721TestToken = require("../../bridge/abi/NFTERC721TestToken.json");
+const abiSideNFTToken = require("../../bridge/abi/SideNFTToken.json");
+const abiDecoder = require("abi-decoder");
+const abiAcceptedNFTCrossTransferEvent = abiNFTBridge.find(
+  (abi) => abi.name === "Cross"
+);
 abiDecoder.addABI([abiAcceptedNFTCrossTransferEvent]);
 
-const TransactionSender = require('../src/lib/TransactionSender.js');
-const FederatorNFT = require('../src/lib/FederatorNFT.ts');
-const utils = require('../src/lib/utils.js');
-const fundFederators = require('./fundFederators');
-const logger = log4js.getLogger('test');
+const TransactionSender = require("../src/lib/TransactionSender.js");
+const FederatorNFT = require("../src/lib/FederatorNFT.ts");
+const utils = require("../src/lib/utils.js");
+const fundFederators = require("./fundFederators");
+const logger = log4js.getLogger("test");
 log4js.configure(logConfig);
-logger.info('----------- Transfer Test ---------------------');
-logger.info('Mainchain Host', config.mainchain.host);
-logger.info('Sidechain Host', config.sidechain.host);
+logger.info("----------- Transfer Test ---------------------");
+logger.info("Mainchain Host", config.mainchain.host);
+logger.info("Sidechain Host", config.sidechain.host);
 const sideConfig = {
-    ...config,
-    confirmations: 0,
-    mainchain: config.sidechain,
-    sidechain: config.mainchain
+  ...config,
+  confirmations: 0,
+  mainchain: config.sidechain,
+  sidechain: config.mainchain,
 };
-const mainKeys = process.argv[2] ? process.argv[2].replace(/ /g, '').split(',') : [];
-const sideKeys = process.argv[3] ? process.argv[3].replace(/ /g, '').split(',') : [];
+const mainKeys = process.argv[2]
+  ? process.argv[2].replace(/ /g, "").split(",")
+  : [];
+const sideKeys = process.argv[3]
+  ? process.argv[3].replace(/ /g, "").split(",")
+  : [];
 const mainchainFederators = getMainchainFederators(mainKeys);
 const sidechainFederators = getSidechainFederators(sideKeys, sideConfig);
-const MAIN_CHAIN_LOGGER_NAME = 'MAIN';
-const SIDE_CHAIN_LOGGER_NAME = 'SIDE';
-const NFT_FEDERATOR_LOGGER_CATEGORY = 'NFT FEDERATOR';
+const MAIN_CHAIN_LOGGER_NAME = "MAIN";
+const SIDE_CHAIN_LOGGER_NAME = "SIDE";
+const NFT_FEDERATOR_LOGGER_CATEGORY = "NFT FEDERATOR";
 
-runNFT({mainchainFederators, sidechainFederators, config, sideConfig});
+runNFT({ mainchainFederators, sidechainFederators, config, sideConfig });
 
 function getMainchainFederators(keys) {
-    let federators = [];
-    if (keys && keys.length) {
-        keys.forEach((key, i) => {
-            let federator = new FederatorNFT.FederatorNFT({
-                ...config,
-                privateKey: key,
-                storagePath: `${config.storagePath}/nft-fed-${i + 1}`
-            }, log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY));
-            federators.push(federator);
-        });
-    } else {
-        let federator = new FederatorNFT.FederatorNFT(config, log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY));
-        federators.push(federator);
-    }
-    return federators;
+  let federators = [];
+  if (keys && keys.length) {
+    keys.forEach((key, i) => {
+      let federator = new FederatorNFT.FederatorNFT(
+        {
+          ...config,
+          privateKey: key,
+          storagePath: `${config.storagePath}/nft-fed-${i + 1}`,
+        },
+        log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY)
+      );
+      federators.push(federator);
+    });
+  } else {
+    let federator = new FederatorNFT.FederatorNFT(
+      config,
+      log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY)
+    );
+    federators.push(federator);
+  }
+  return federators;
 }
 
 function getSidechainFederators(keys, sideConfig) {
-    let federators = [];
-    if (keys && keys.length) {
-        keys.forEach((key, i) => {
-            let federator = new FederatorNFT.FederatorNFT({
-                    ...sideConfig,
-                    privateKey: key,
-                    storagePath: `${config.storagePath}/nft-side-fed-${i + 1}`
-                },
-                log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY));
-            federators.push(federator);
-        });
-    } else {
-        let federator = new FederatorNFT.FederatorNFT({
-            ...sideConfig,
-            storagePath: `${config.storagePath}/side-fed`
-        }, log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY));
-        federators.push(federator);
-    }
-    return federators;
-}
-
-async function runNFT({mainchainFederators, sidechainFederators, config, sideConfig}) {
-    logger.info('[NFT] Starting transfer from Mainchain to Sidechain');
-    await transferNFT(mainchainFederators, sidechainFederators, config, MAIN_CHAIN_LOGGER_NAME, SIDE_CHAIN_LOGGER_NAME);
-    logger.info('[NFT] Completed transfer from Mainchain to Sidechain');
-
-    logger.info('[NFT] Starting transfer from Sidechain to Mainchain');
-    await transferNFT(sidechainFederators, mainchainFederators, sideConfig, SIDE_CHAIN_LOGGER_NAME, MAIN_CHAIN_LOGGER_NAME);
-    logger.info('[NFT] Completed transfer from Sidechain to Mainchain');
-}
-
-async function transferNFT(originFederators, destinationFederators, config, originLoggerName, destinationLoggerName) {
-    try {
-        const mainChainWeb3 = new Web3(config.mainchain.host);
-        const sideChainWeb3 = new Web3(config.sidechain.host);
-        const transactionSender = new TransactionSender(mainChainWeb3, logger, config);
-        const destinationTransactionSender = new TransactionSender(sideChainWeb3, logger, config);
-        const originNftBridgeAddress = config.mainchain.nftBridge;
-        const destinationNftBridgeAddress = config.sidechain.nftBridge;
-        const originTokenContract = new mainChainWeb3.eth.Contract(abiNFTERC721TestToken, config.mainchain.testTokenNft);
-        const originTokenAddress = originTokenContract.options.address;
-        const sideMultiSigContract = new mainChainWeb3.eth.Contract(abiMultiSig, config.sidechain.multiSig);
-        const originNftBridgeContract = new mainChainWeb3.eth.Contract(abiNFTBridge, originNftBridgeAddress);
-        const nftBridgeFederation = await originNftBridgeContract.methods.getFederation().call();
-        logger.info(`Federation from NFT bridge: ${nftBridgeFederation}`);
-        const destinationNftBridgeContract = new sideChainWeb3.eth.Contract(abiNFTBridge, destinationNftBridgeAddress);
-
-        logger.debug('Get the destination token address');
-
-        // Pick token id to mint according to total supply, to be able to run the test N times without redeploying the contracts.
-        let tokenSupply = await originTokenContract.methods.totalSupply().call();
-        const tokenId = parseInt(tokenSupply);
-
-        const tokenSymbol = 'drop';
-        const tokenName = 'The Drops';
-        const tokenBaseURI = 'ipfs:/';
-        const tokenContractURI = 'https://api-mainnet.rarible.com/contractMetadata';
-        const destinationTokenAddress = await getDestinationNFTTokenAddress(destinationNftBridgeContract, originTokenAddress,
-            sideMultiSigContract, destinationTransactionSender, config, destinationLoggerName, tokenSymbol, tokenName,
-            tokenBaseURI, tokenContractURI);
-        const sideTokenContract = new sideChainWeb3.eth.Contract(abiSideNFTToken, destinationTokenAddress);
-
-        logger.info('------------- SENDING THE TOKENS -----------------');
-        logger.debug('Getting address from pk');
-        const userPrivateKey = mainChainWeb3.eth.accounts.create().privateKey;
-        const userAddress = await transactionSender.getAddress(userPrivateKey);
-        await transactionSender.sendTransaction(userAddress, '', mainChainWeb3.utils.toWei('1'), config.privateKey);
-        await destinationTransactionSender.sendTransaction(userAddress, '', mainChainWeb3.utils.toWei('1'),
-            config.privateKey, true);
-        logger.info(`${originLoggerName} token address ${originTokenAddress} - User Address: ${userAddress}`);
-
-        let expectedTokenAmount = 0;
-        await assertNFTTokenBalanceForUserIsExpected(originTokenContract, userAddress, expectedTokenAmount);
-
-        await mintNFTTokenToUser(originTokenContract, userAddress, tokenId, transactionSender, config);
-
-        expectedTokenAmount = 1;
-        await assertNFTTokenBalanceForUserIsExpected(originTokenContract, userAddress, expectedTokenAmount);
-
-        await approveBridgeToMoveToken(originTokenContract, originNftBridgeAddress, tokenId, userAddress,
-            transactionSender, userPrivateKey);
-
-        let receiveTokensToTxReceipt = await receiveTokensToMainChainBridge(originNftBridgeContract, originTokenAddress,
-            userAddress, tokenId, transactionSender, originNftBridgeAddress, userPrivateKey);
-
-        await startAndFundFederators(config, mainChainWeb3, sideChainWeb3, originFederators);
-
-        await assertThatNftTokensCrossedToBridge(destinationNftBridgeContract, receiveTokensToTxReceipt.transactionHash);
-        logger.info('Tokens were received in side chain Bridge');
-
-        await claimNftTokenInSideChain(receiveTokensToTxReceipt, destinationNftBridgeContract, userAddress, tokenId,
-            originTokenAddress, destinationTransactionSender, userPrivateKey);
-
-        expectedTokenAmount = 0;
-        await assertNFTTokenBalanceForUserIsExpected(originTokenContract, userAddress, expectedTokenAmount);
-
-        expectedTokenAmount = 1;
-        await assertNFTTokenBalanceForUserIsExpected(sideTokenContract, userAddress, expectedTokenAmount);
-    } catch (err) {
-        logger.error('Unhandled error:', err.stack);
-        process.exit(1);
-    }
-}
-
-async function getDestinationNFTTokenAddress(destinationBridgeContract, originAddress, sideMultiSigContract,
-                                             destinationTransactionSender, config, destinationLoggerName, symbol, name, baseURI, contractURI) {
-    let destinationTokenAddress = await destinationBridgeContract.methods.sideTokenAddressByOriginalTokenAddress(originAddress).call();
-    if (destinationTokenAddress === utils.zeroAddress) {
-        logger.info('Side NFT Token does not exist yet, creating it');
-        let bridgeAddress = await destinationBridgeContract.options.address;
-        const data = destinationBridgeContract.methods.createSideNFTToken(originAddress, symbol, name, baseURI, contractURI)
-            .encodeABI();
-        const multiSigData = sideMultiSigContract.methods.submitTransaction(bridgeAddress, 0, data)
-            .encodeABI();
-        await destinationTransactionSender.sendTransaction(config.sidechain.multiSig, multiSigData, 0, '', true);
-        destinationTokenAddress = await destinationBridgeContract.methods.sideTokenAddressByOriginalTokenAddress(originAddress).call();
-        if (destinationTokenAddress === utils.zeroAddress) {
-            logger.error('Failed to create side NFT token');
-            process.exit(1);
-        }
-    }
-    logger.info(`${destinationLoggerName} token address`, destinationTokenAddress);
-    return destinationTokenAddress;
-}
-
-async function assertThatNftTokensCrossedToBridge(nftBridgeContract, transactionHash) {
-    const txDataHash = await nftBridgeContract.methods.hasCrossed(transactionHash).call();
-    if (txDataHash === utils.zeroHash) {
-        logger.error('Token was not voted by federators');
-        process.exit(1);
-    }
-}
-
-async function assertNFTTokenBalanceForUserIsExpected(tokenContract, userAddress, expectedTokenAmount) {
-    const nftTokenBalanceForUser = await tokenContract.methods.balanceOf(userAddress).call();
-    if (!web3Utils.toBN(nftTokenBalanceForUser).eq(web3Utils.toBN(expectedTokenAmount))) {
-        logger.error(`User ${userAddress}'s balance for token ${tokenContract.options.address} should be ${expectedTokenAmount} but is ${nftTokenBalanceForUser}`);
-        process.exit(1);
-    }
-}
-
-async function mintNFTTokenToUser(tokenContract, userAddress, tokenId, transactionSender, config) {
-    const methodCall = tokenContract.methods.safeMint(userAddress, tokenId);
-    await methodCall.call({from: userAddress});
-    const data = methodCall.encodeABI();
-    await transactionSender.sendTransaction(tokenContract.options.address, data, 0, config.privateKey, true);
-}
-
-async function approveBridgeToMoveToken(originTokenContract, originNftBridgeAddress, tokenId, userAddress,
-                                        transactionSender, userPrivateKey) {
-    const methodCall = originTokenContract.methods.approve(originNftBridgeAddress, tokenId);
-    await methodCall.call({from: userAddress});
-    const data = methodCall.encodeABI();
-    await transactionSender.sendTransaction(originTokenContract.options.address, data, 0, userPrivateKey, true);
-}
-
-async function receiveTokensToMainChainBridge(originNftBridgeContract, originTokenAddress, userAddress, tokenId,
-                                              transactionSender, originNftBridgeAddress, userPrivateKey) {
-    const methodCall = originNftBridgeContract.methods.receiveTokensTo(originTokenAddress, userAddress, tokenId);
-    await methodCall.call({from: userAddress});
-    const data = methodCall.encodeABI();
-    return await transactionSender.sendTransaction(originNftBridgeAddress, data, 0, userPrivateKey, true);
-}
-
-async function startAndFundFederators(config, mainChainWeb3, sideChainWeb3, originFederators) {
-    const waitBlocks = config.confirmations || 0;
-    logger.debug(`Wait for ${waitBlocks} blocks`);
-    await utils.waitBlocks(mainChainWeb3, waitBlocks);
-
-    logger.debug('Starting federator processes');
-
-    // Start origin federators with delay between them.
-    logger.debug('Fund federator wallets');
-    let federatorKeys = mainKeys && mainKeys.length ? mainKeys : [config.privateKey];
-    await fundFederators(config.sidechain.host, federatorKeys, config.sidechain.privateKey, sideChainWeb3.utils.toWei('1'));
-
-    await originFederators.reduce(function (promise, item) {
-        return promise.then(function () {
-            return item.run();
-        });
-    }, Promise.resolve());
-}
-
-async function claimNftTokenInSideChain(receiveTokensToTxReceipt, destinationNftBridgeContract, userAddress, tokenId,
-                                        originTokenAddress, destinationTransactionSender, userPrivateKey) {
-    const acceptTransferEventDecodedLogs = abiDecoder.decodeLogs(receiveTokensToTxReceipt.logs);
-    if (acceptTransferEventDecodedLogs.length !== 1) {
-        logger.error(`Expected a single accept transfer event to have been emitted, but got ${acceptTransferEventDecodedLogs.length}`);
-        process.exit(1);
-    }
-
-    const acceptTransferEventAddress = acceptTransferEventDecodedLogs[0].address;
-    const acceptTransferEventLog = receiveTokensToTxReceipt.logs.find(log => log.address === acceptTransferEventAddress);
-
-    const methodCall = destinationNftBridgeContract.methods.claim(
+  let federators = [];
+  if (keys && keys.length) {
+    keys.forEach((key, i) => {
+      let federator = new FederatorNFT.FederatorNFT(
         {
-            to: userAddress,
-            from: userAddress,
-            tokenId: tokenId,
-            tokenAddress: originTokenAddress,
-            blockHash: acceptTransferEventLog.blockHash,
-            transactionHash: acceptTransferEventLog.transactionHash,
-            logIndex: acceptTransferEventLog.logIndex
-        }
+          ...sideConfig,
+          privateKey: key,
+          storagePath: `${config.storagePath}/nft-side-fed-${i + 1}`,
+        },
+        log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY)
+      );
+      federators.push(federator);
+    });
+  } else {
+    let federator = new FederatorNFT.FederatorNFT(
+      {
+        ...sideConfig,
+        storagePath: `${config.storagePath}/side-fed`,
+      },
+      log4js.getLogger(NFT_FEDERATOR_LOGGER_CATEGORY)
     );
-    await methodCall.call({from: userAddress});
-    const data = methodCall.encodeABI();
-    await destinationTransactionSender.sendTransaction(destinationNftBridgeContract.options.address, data, 0, userPrivateKey, true);
+    federators.push(federator);
+  }
+  return federators;
+}
+
+async function runNFT({
+  mainchainFederators,
+  sidechainFederators,
+  config,
+  sideConfig,
+}) {
+  logger.info("[NFT] Starting transfer from Mainchain to Sidechain");
+  await transferNFT(
+    mainchainFederators,
+    sidechainFederators,
+    config,
+    MAIN_CHAIN_LOGGER_NAME,
+    SIDE_CHAIN_LOGGER_NAME
+  );
+  logger.info("[NFT] Completed transfer from Mainchain to Sidechain");
+
+  logger.info("[NFT] Starting transfer from Sidechain to Mainchain");
+  await transferNFT(
+    sidechainFederators,
+    mainchainFederators,
+    sideConfig,
+    SIDE_CHAIN_LOGGER_NAME,
+    MAIN_CHAIN_LOGGER_NAME
+  );
+  logger.info("[NFT] Completed transfer from Sidechain to Mainchain");
+}
+
+async function transferNFT(
+  originFederators,
+  destinationFederators,
+  config,
+  originLoggerName,
+  destinationLoggerName
+) {
+  try {
+    const originChainWeb3 = new Web3(config.mainchain.host);
+    const originChainId = await originChainWeb3.eth.net.getId();
+    const destinationChainWeb3 = new Web3(config.sidechain.host);
+    const destinationChainId = await destinationChainWeb3.eth.net.getId();
+
+    const transactionSender = new TransactionSender(
+      originChainWeb3,
+      logger,
+      config
+    );
+    const destinationTransactionSender = new TransactionSender(
+      destinationChainWeb3,
+      logger,
+      config
+    );
+    const originNftBridgeAddress = config.mainchain.nftBridge;
+    const destinationNftBridgeAddress = config.sidechain.nftBridge;
+    const originTokenContract = new originChainWeb3.eth.Contract(
+      abiNFTERC721TestToken,
+      config.mainchain.testTokenNft
+    );
+    const originTokenAddress = originTokenContract.options.address;
+    const sideMultiSigContract = new originChainWeb3.eth.Contract(
+      abiMultiSig,
+      config.sidechain.multiSig
+    );
+    const originNftBridgeContract = new originChainWeb3.eth.Contract(
+      abiNFTBridge,
+      originNftBridgeAddress
+    );
+    const nftBridgeFederation = await originNftBridgeContract.methods
+      .getFederation()
+      .call();
+    logger.info(`Federation from NFT bridge: ${nftBridgeFederation}`);
+    const destinationNftBridgeContract = new destinationChainWeb3.eth.Contract(
+      abiNFTBridge,
+      destinationNftBridgeAddress
+    );
+
+    logger.debug("Get the destination token address");
+
+    // Pick token id to mint according to total supply, to be able to run the test N times without redeploying the contracts.
+    let tokenSupply = await originTokenContract.methods.totalSupply().call();
+    const tokenId = parseInt(tokenSupply);
+
+    const tokenSymbol = "drop";
+    const tokenName = "The Drops";
+    const tokenBaseURI = "ipfs:/";
+    const tokenContractURI = "https://api-mainnet.rarible.com/contractMetadata";
+    const destinationTokenAddress = await getDestinationNFTTokenAddress(
+      destinationNftBridgeContract,
+      originTokenAddress,
+      originChainId,
+      sideMultiSigContract,
+      destinationTransactionSender,
+      config,
+      destinationLoggerName,
+      tokenSymbol,
+      tokenName,
+      tokenBaseURI,
+      tokenContractURI
+    );
+    const sideTokenContract = new destinationChainWeb3.eth.Contract(
+      abiSideNFTToken,
+      destinationTokenAddress
+    );
+
+    logger.info("------------- SENDING THE TOKENS -----------------");
+    logger.debug("Getting address from pk");
+    const userPrivateKey = originChainWeb3.eth.accounts.create().privateKey;
+    const userAddress = await transactionSender.getAddress(userPrivateKey);
+    await transactionSender.sendTransaction(
+      userAddress,
+      "",
+      originChainWeb3.utils.toWei("1"),
+      config.privateKey
+    );
+    await destinationTransactionSender.sendTransaction(
+      userAddress,
+      "",
+      originChainWeb3.utils.toWei("1"),
+      config.privateKey,
+      true
+    );
+    logger.info(
+      `${originLoggerName} token address ${originTokenAddress} - User Address: ${userAddress}`
+    );
+
+    let expectedTokenAmount = 0;
+    await assertNFTTokenBalanceForUserIsExpected(
+      originTokenContract,
+      userAddress,
+      expectedTokenAmount
+    );
+
+    await mintNFTTokenToUser(
+      originTokenContract,
+      userAddress,
+      tokenId,
+      transactionSender,
+      config
+    );
+
+    expectedTokenAmount = 1;
+    await assertNFTTokenBalanceForUserIsExpected(
+      originTokenContract,
+      userAddress,
+      expectedTokenAmount
+    );
+
+    await approveBridgeToMoveToken(
+      originTokenContract,
+      originNftBridgeAddress,
+      tokenId,
+      userAddress,
+      transactionSender,
+      userPrivateKey
+    );
+
+    let receiveTokensToTxReceipt = await receiveTokensToMainChainBridge(
+      originNftBridgeContract,
+      originTokenAddress,
+      destinationChainId,
+      userAddress,
+      tokenId,
+      transactionSender,
+      originNftBridgeAddress,
+      userPrivateKey
+    );
+
+    await startAndFundFederators(
+      config,
+      originChainWeb3,
+      destinationChainWeb3,
+      originFederators
+    );
+
+    await assertThatNftTokensCrossedToBridge(
+      destinationNftBridgeContract,
+      receiveTokensToTxReceipt.transactionHash
+    );
+    logger.info("Tokens were received in side chain Bridge");
+
+    await claimNftTokenInSideChain(
+      receiveTokensToTxReceipt,
+      destinationNftBridgeContract,
+      userAddress,
+      tokenId,
+      originTokenAddress,
+      destinationTransactionSender,
+      userPrivateKey,
+      originChainId
+    );
+
+    expectedTokenAmount = 0;
+    await assertNFTTokenBalanceForUserIsExpected(
+      originTokenContract,
+      userAddress,
+      expectedTokenAmount
+    );
+
+    expectedTokenAmount = 1;
+    await assertNFTTokenBalanceForUserIsExpected(
+      sideTokenContract,
+      userAddress,
+      expectedTokenAmount
+    );
+  } catch (err) {
+    logger.error("Unhandled error:", err.stack);
+    process.exit(1);
+  }
+}
+
+async function getDestinationNFTTokenAddress(
+  destinationBridgeContract,
+  originAddress,
+  originChainId,
+  sideMultiSigContract,
+  destinationTransactionSender,
+  config,
+  destinationLoggerName,
+  symbol,
+  name,
+  baseURI,
+  contractURI
+) {
+  let destinationTokenAddress = await destinationBridgeContract.methods
+    .getSideTokenByOriginalToken(originChainId, originAddress)
+    .call();
+  if (destinationTokenAddress === utils.zeroAddress) {
+    logger.info("Side NFT Token does not exist yet, creating it");
+    let bridgeAddress = await destinationBridgeContract.options.address;
+    const data = destinationBridgeContract.methods
+      .createSideNFTToken(
+        originAddress,
+        symbol,
+        name,
+        baseURI,
+        contractURI,
+        originChainId
+      )
+      .encodeABI();
+    const multiSigData = sideMultiSigContract.methods
+      .submitTransaction(bridgeAddress, 0, data)
+      .encodeABI();
+    await destinationTransactionSender.sendTransaction(
+      config.sidechain.multiSig,
+      multiSigData,
+      0,
+      "",
+      true
+    );
+    destinationTokenAddress = await destinationBridgeContract.methods
+      .getSideTokenByOriginalToken(originChainId, originAddress)
+      .call();
+    if (destinationTokenAddress === utils.zeroAddress) {
+      logger.error("Failed to create side NFT token");
+      process.exit(1);
+    }
+  }
+  logger.info(
+    `${destinationLoggerName} token address`,
+    destinationTokenAddress
+  );
+  return destinationTokenAddress;
+}
+
+async function assertThatNftTokensCrossedToBridge(
+  nftBridgeContract,
+  transactionHash
+) {
+  const txDataHash = await nftBridgeContract.methods
+    .hasCrossed(transactionHash)
+    .call();
+  if (txDataHash === utils.zeroHash) {
+    logger.error("Token was not voted by federators");
+    process.exit(1);
+  }
+}
+
+async function assertNFTTokenBalanceForUserIsExpected(
+  tokenContract,
+  userAddress,
+  expectedTokenAmount
+) {
+  const nftTokenBalanceForUser = await tokenContract.methods
+    .balanceOf(userAddress)
+    .call();
+  if (
+    !web3Utils
+      .toBN(nftTokenBalanceForUser)
+      .eq(web3Utils.toBN(expectedTokenAmount))
+  ) {
+    logger.error(
+      `User ${userAddress}'s balance for token ${tokenContract.options.address} should be ${expectedTokenAmount} but is ${nftTokenBalanceForUser}`
+    );
+    process.exit(1);
+  }
+}
+
+async function mintNFTTokenToUser(
+  tokenContract,
+  userAddress,
+  tokenId,
+  transactionSender,
+  config
+) {
+  const methodCall = tokenContract.methods.safeMint(userAddress, tokenId);
+  await methodCall.call({ from: userAddress });
+  const data = methodCall.encodeABI();
+  await transactionSender.sendTransaction(
+    tokenContract.options.address,
+    data,
+    0,
+    config.privateKey,
+    true
+  );
+}
+
+async function approveBridgeToMoveToken(
+  originTokenContract,
+  originNftBridgeAddress,
+  tokenId,
+  userAddress,
+  transactionSender,
+  userPrivateKey
+) {
+  const methodCall = originTokenContract.methods.approve(
+    originNftBridgeAddress,
+    tokenId
+  );
+  await methodCall.call({ from: userAddress });
+  const data = methodCall.encodeABI();
+  await transactionSender.sendTransaction(
+    originTokenContract.options.address,
+    data,
+    0,
+    userPrivateKey,
+    true
+  );
+}
+
+async function receiveTokensToMainChainBridge(
+  originNftBridgeContract,
+  originTokenAddress,
+  destinationChainId,
+  userAddress,
+  tokenId,
+  transactionSender,
+  originNftBridgeAddress,
+  userPrivateKey
+) {
+  const methodCall = originNftBridgeContract.methods.receiveTokensTo(
+    originTokenAddress,
+    userAddress,
+    tokenId,
+    destinationChainId
+  );
+  await methodCall.call({ from: userAddress });
+  const data = methodCall.encodeABI();
+  return await transactionSender.sendTransaction(
+    originNftBridgeAddress,
+    data,
+    0,
+    userPrivateKey,
+    true
+  );
+}
+
+async function startAndFundFederators(
+  config,
+  mainChainWeb3,
+  sideChainWeb3,
+  originFederators
+) {
+  const waitBlocks = config.confirmations || 0;
+  logger.debug(`Wait for ${waitBlocks} blocks`);
+  await utils.waitBlocks(mainChainWeb3, waitBlocks);
+
+  logger.debug("Starting federator processes");
+
+  // Start origin federators with delay between them.
+  logger.debug("Fund federator wallets");
+  let federatorKeys =
+    mainKeys && mainKeys.length ? mainKeys : [config.privateKey];
+  await fundFederators(
+    config.sidechain.host,
+    federatorKeys,
+    config.sidechain.privateKey,
+    sideChainWeb3.utils.toWei("1")
+  );
+
+  await originFederators.reduce(function (promise, item) {
+    return promise.then(function () {
+      return item.run();
+    });
+  }, Promise.resolve());
+}
+
+async function claimNftTokenInSideChain(
+  receiveTokensToTxReceipt,
+  destinationNftBridgeContract,
+  userAddress,
+  tokenId,
+  originTokenAddress,
+  destinationTransactionSender,
+  userPrivateKey,
+  originChainId
+) {
+  const acceptTransferEventDecodedLogs = abiDecoder.decodeLogs(
+    receiveTokensToTxReceipt.logs
+  );
+  if (acceptTransferEventDecodedLogs.length !== 1) {
+    logger.error(
+      `Expected a single accept transfer event to have been emitted, but got ${acceptTransferEventDecodedLogs.length}`
+    );
+    process.exit(1);
+  }
+
+  const acceptTransferEventAddress = acceptTransferEventDecodedLogs[0].address;
+  const acceptTransferEventLog = receiveTokensToTxReceipt.logs.find(
+    (log) => log.address === acceptTransferEventAddress
+  );
+
+  const methodCall = destinationNftBridgeContract.methods.claim({
+    to: userAddress,
+    from: userAddress,
+    tokenId: tokenId,
+    tokenAddress: originTokenAddress,
+    blockHash: acceptTransferEventLog.blockHash,
+    transactionHash: acceptTransferEventLog.transactionHash,
+    logIndex: acceptTransferEventLog.logIndex,
+    originChainId: originChainId,
+  });
+
+  await methodCall.call({ from: userAddress });
+  const data = methodCall.encodeABI();
+  await destinationTransactionSender.sendTransaction(
+    destinationNftBridgeContract.options.address,
+    data,
+    0,
+    userPrivateKey,
+    true
+  );
 }

--- a/federator/src/contracts/AllowTokensFactory.ts
+++ b/federator/src/contracts/AllowTokensFactory.ts
@@ -10,7 +10,7 @@ import { Config } from '../../config/types';
 import { IAllowTokensV2 } from './IAllowTokensV2';
 import { ContractFactory } from './ContractFactory';
 import { AbiItem } from 'web3-utils';
-import { V0, V1, V2 } from './Constants';
+import { VERSIONS } from './Constants';
 import { Logger } from 'log4js';
 
 export class AllowTokensFactory extends ContractFactory {
@@ -32,7 +32,7 @@ export class AllowTokensFactory extends ContractFactory {
     try {
       return await utils.retry3Times(allowTokensContract.methods.version().call);
     } catch (err) {
-      return 'v0';
+      return VERSIONS.V0;
     }
   }
 
@@ -42,12 +42,12 @@ export class AllowTokensFactory extends ContractFactory {
     const chainId = await utils.retry3Times(web3.eth.net.getId);
 
     switch (version) {
-      case V2:
+      case VERSIONS.V2:
         return new IAllowTokensV2(allowTokensContract, chainId);
-      case V1:
+      case VERSIONS.V1:
         allowTokensContract = this.getContractByAbi(abiAllowTokensV1 as AbiItem[], address, web3);
         return new IAllowTokensV1(allowTokensContract);
-      case V0:
+      case VERSIONS.V0:
         allowTokensContract = this.getContractByAbi(abiAllowTokensV0 as AbiItem[], address, web3);
         return new IAllowTokensV0(allowTokensContract, chainId);
       default:

--- a/federator/src/contracts/BridgeFactory.ts
+++ b/federator/src/contracts/BridgeFactory.ts
@@ -9,7 +9,7 @@ import CustomError from '../lib/CustomError';
 import utils from '../lib/utils';
 import { AbiItem } from 'web3-utils';
 import { ContractFactory } from './ContractFactory';
-import { V1, V2, V3, V4 } from './Constants';
+import { VERSIONS } from './Constants';
 import { Config } from '../../config/types';
 import { Contract } from 'web3-eth-contract';
 import Web3 from 'web3';
@@ -29,13 +29,13 @@ export class BridgeFactory extends ContractFactory {
     const version = await this.getVersion(bridgeContract);
     const chainId = await web3.eth.net.getId();
     switch (version) {
-      case V4:
+      case VERSIONS.V4:
         return new IBridgeV4(bridgeContract, chainId);
-      case V3:
+      case VERSIONS.V3:
         bridgeContract = this.getContractByAbi(abiBridgeV3 as AbiItem[], address, web3);
         return new IBridge(bridgeContract);
-      case V2:
-      case V1:
+      case VERSIONS.V2:
+      case VERSIONS.V1:
         bridgeContract = this.getContractByAbi(abiBridgeV2 as AbiItem[], address, web3);
         return new IBridge(bridgeContract);
       default:

--- a/federator/src/contracts/Constants.ts
+++ b/federator/src/contracts/Constants.ts
@@ -1,5 +1,7 @@
-export const V4 = 'v4';
-export const V3 = 'v3';
-export const V2 = 'v2';
-export const V1 = 'v1';
-export const V0 = 'v0';
+export const VERSIONS = {
+  V4: 'v4',
+  V3: 'v3',
+  V2: 'v2',
+  V1: 'v1',
+  V0: 'v0',
+};

--- a/federator/src/contracts/FederationFactory.ts
+++ b/federator/src/contracts/FederationFactory.ts
@@ -109,7 +109,7 @@ export class FederationFactory extends ContractFactory {
   }
 
   createFederatorInstance(web3, address) {
-    const federationContract = this.getContractByAbi(abiFederationV3 as AbiItem[], address, web3);
-    return new IFederationV3(this.config, federationContract);
+    const federationContract = this.getContractByAbi(abiFederationV4 as AbiItem[], address, web3);
+    return new IFederationV4(this.config, federationContract);
   }
 }

--- a/federator/src/contracts/FederationFactory.ts
+++ b/federator/src/contracts/FederationFactory.ts
@@ -8,7 +8,7 @@ import { IFederationV3 } from './IFederationV3';
 import { IFederationV4 } from './IFederationV4';
 import CustomError from '../lib/CustomError';
 import utils from '../lib/utils';
-import { V2, V3, V4 } from './Constants';
+import { VERSIONS } from './Constants';
 import { ContractFactory } from './ContractFactory';
 import { AbiItem } from 'web3-utils';
 import { Logger } from 'log4js';
@@ -51,12 +51,12 @@ export class FederationFactory extends ContractFactory {
     const version = await this.getVersion(federationContract);
 
     switch (version) {
-      case V4:
+      case VERSIONS.V4:
         return new IFederationV4(this.config, federationContract);
-      case V3:
+      case VERSIONS.V3:
         federationContract = this.getContractByAbi(abiFederationV3 as AbiItem[], address, web3);
         return new IFederationV3(this.config, federationContract);
-      case V2:
+      case VERSIONS.V2:
         federationContract = this.getContractByAbi(abiFederationV2 as AbiItem[], address, web3);
         return new IFederationV2(this.config, federationContract);
       default:

--- a/federator/src/contracts/IAllowTokensV0.ts
+++ b/federator/src/contracts/IAllowTokensV0.ts
@@ -1,5 +1,5 @@
 import { Contract } from 'web3-eth-contract';
-import { V0 } from './Constants';
+import { VERSIONS } from './Constants';
 
 export class IAllowTokensV0 {
   allowTokensContract: Contract;
@@ -13,7 +13,7 @@ export class IAllowTokensV0 {
   }
 
   getVersion() {
-    return V0;
+    return VERSIONS.V0;
   }
 
   async getConfirmations() {

--- a/federator/src/contracts/IAllowTokensV1.ts
+++ b/federator/src/contracts/IAllowTokensV1.ts
@@ -1,6 +1,6 @@
 import { Contract } from 'web3-eth-contract';
 import CustomError from '../lib/CustomError';
-import { V1 } from './Constants';
+import { VERSIONS } from './Constants';
 
 export class IAllowTokensV1 {
   allowTokensContract: Contract;
@@ -12,7 +12,7 @@ export class IAllowTokensV1 {
   }
 
   getVersion() {
-    return V1;
+    return VERSIONS.V1;
   }
 
   async getConfirmations() {

--- a/federator/src/contracts/IAllowTokensV2.ts
+++ b/federator/src/contracts/IAllowTokensV2.ts
@@ -1,5 +1,5 @@
 import CustomError from '../lib/CustomError';
-import { V2 } from './Constants';
+import { VERSIONS } from './Constants';
 
 interface GetLimitsParams {
   tokenAddress: string;
@@ -17,7 +17,7 @@ export class IAllowTokensV2 {
   }
 
   getVersion() {
-    return V2;
+    return VERSIONS.V2;
   }
 
   async getConfirmations() {

--- a/federator/src/contracts/IBridgeNft.ts
+++ b/federator/src/contracts/IBridgeNft.ts
@@ -25,7 +25,7 @@ export class IBridgeNft {
     return this.nftBridgeContract.methods.version().call();
   }
 
-  getMappedToken(originalTokenAddress) {
-    return this.nftBridgeContract.methods.sideTokenAddressByOriginalTokenAddress(originalTokenAddress);
+  getMappedToken({ originalTokenAddress, chainId }) {
+    return this.nftBridgeContract.methods.getSideTokenByOriginalToken(chainId, originalTokenAddress);
   }
 }

--- a/federator/src/contracts/IFederationV2.ts
+++ b/federator/src/contracts/IFederationV2.ts
@@ -1,6 +1,6 @@
 import { Config } from '../../config/types';
 import { Contract } from 'web3-eth-contract';
-import { V2 } from './Constants';
+import { VERSIONS } from './Constants';
 
 export class IFederationV2 {
   federationContract: Contract;
@@ -12,7 +12,7 @@ export class IFederationV2 {
   }
 
   getVersion() {
-    return V2;
+    return VERSIONS.V2;
   }
 
   isMember(address: string) {

--- a/federator/src/contracts/IFederationV4.ts
+++ b/federator/src/contracts/IFederationV4.ts
@@ -6,9 +6,9 @@ interface TransactionIdParams {
   sender: string;
   receiver: string;
   amount: number;
-  blockHash: number;
+  blockHash: string;
   transactionHash: string;
-  logIndex: string;
+  logIndex: number;
   originChainId: number;
   destinationChainId: number;
 }

--- a/federator/src/contracts/IFederationV4.ts
+++ b/federator/src/contracts/IFederationV4.ts
@@ -1,11 +1,12 @@
 import { Config } from '../../config/types';
 import { Contract, EventData } from 'web3-eth-contract';
+import { BN } from 'ethereumjs-util';
 
 interface TransactionIdParams {
   originalTokenAddress: string;
   sender: string;
   receiver: string;
-  amount: number;
+  amount: BN;
   blockHash: string;
   transactionHash: string;
   logIndex: number;

--- a/federator/src/lib/FederatorNFT.ts
+++ b/federator/src/lib/FederatorNFT.ts
@@ -12,6 +12,7 @@ import * as typescriptUtils from './typescriptUtils';
 import { RSK_TEST_NET_CHAIN_ID, ETH_KOVAN_CHAIN_ID, ETH_MAIN_NET_CHAIN_ID, RSK_MAIN_NET_CHAIN_ID } from './chainId';
 import { MetricCollector } from './MetricCollector';
 import { IFederationV4 } from '../contracts/IFederationV4';
+import { BN } from 'ethereumjs-util';
 
 export class FederatorNFT {
   public logger: Logger;
@@ -222,7 +223,7 @@ export class FederatorNFT {
 
         const originChainId = Number(originChainIdStr);
         const destinationChainId = Number(destinationChainIdStr);
-        const tokenId = Number(tokenIdStr);
+        const tokenId = new BN(tokenIdStr);
 
         const originalTokenAddress = log.returnValues._originalTokenAddress.toLowerCase();
         const blocksConfirmed = currentBlock - blockNumber;
@@ -297,7 +298,7 @@ export class FederatorNFT {
     originalTokenAddress: string,
     sender: string,
     receiver: string,
-    tokenId: number,
+    tokenId: BN,
     blockHash: string,
     transactionHash: string,
     logIndex: number,
@@ -354,7 +355,7 @@ export class FederatorNFT {
     originalTokenAddress: string,
     sender: string,
     receiver: string,
-    tokenId: number,
+    tokenId: BN,
     blockHash: string,
     transactionHash: string,
     logIndex: number,


### PR DESCRIPTION
### Integration test for multichain contracts

Add multichain logic into the NFT contracts, federator, and tests

### Description

- Add multichain logic to 
   - NFT contracts
   - Federator
   - Nft Integration tests

### How to Test

- Run both `ganache-cli`
- Enter into the bridge directory and run all the tests

#### Case 1

1. Go to bridge directory
```shell
$~ cd bridge
```

2. Run all the tests
```shell
$~ npm run test
```

__Expected Result__
- It should pass the test
![image](https://user-images.githubusercontent.com/17556614/131563928-05d6cb84-caf0-4ee0-8458-3464257e7f6c.png)

3. Run the first ganache-cli
```shell
$~ npm run ganache
```

4. Open another shell and run the ganache mirror
```shell
$~ npm run ganache-mirror
```

5. Go to the federator directory
```shell
$~ cd ../federator
```

6. Run the integration test
```shell
$~ npm run integrationTest
```

__Expected Result__
- It should pass the test
![image](https://user-images.githubusercontent.com/17556614/137998725-3938ce87-87b1-4631-9cff-095935854d6e.png)


7. Run the NFT integration test
```shell
$~ npm run nftIntegrationTest
```
__Expected Result__
- It should pass the test
![image](https://user-images.githubusercontent.com/17556614/137998804-e984a70a-2ae3-4cc4-861e-83c691d53a77.png)


### Checklist

#### Bridge Directory `cd bridge`
- [x] Lint is clean `npm run lint`
- [x] Test is passing `npm run test`
- [x] Contracts are compiling `npm run compile`

#### Federator Directory `cd federator`
- [x] Lint is clean `npm run lint`
- [x] Test is passing `npm run test`
- [x] Typescript is compiling `npm run build`