### PR TITLE
Give a warning when addres is not part of the fed

### DIFF
--- a/federator/src/lib/Federator.ts
+++ b/federator/src/lib/Federator.ts
@@ -123,7 +123,7 @@ export default abstract class Federator {
       const isMember = await fedContract.isMember(from);
       if (!isMember) {
         this.logger.warn(`This Federator addr:${from} is not part of the federation. Skipping to next scheduled poll.`)
-        return;
+        return false;
       }
       this.logger.upsertContext('Retrie', this.getCurrentRetrie());
       try {

--- a/federator/src/lib/Federator.ts
+++ b/federator/src/lib/Federator.ts
@@ -118,7 +118,7 @@ export default abstract class Federator {
       const sideChainWeb3 = this.getWeb3(sideChainConfig.host);
       const transactionSender = new TransactionSender(sideChainWeb3, this.logger, this.config);
       const federationFactory = new FederationFactory();
-      const fedContract = await federationFactory.createInstance(this.config.mainchain, this.config.privateKey);
+      const fedContract = await federationFactory.createInstance(sideChainConfig, this.config.privateKey);
       const from = await transactionSender.getAddress(this.config.privateKey);
       const isMember = await fedContract.isMember(from);
       if (!isMember) {

--- a/federator/src/lib/Federator.ts
+++ b/federator/src/lib/Federator.ts
@@ -117,11 +117,18 @@ export default abstract class Federator {
       this.resetRetries();
       const sideChainWeb3 = this.getWeb3(sideChainConfig.host);
       const transactionSender = new TransactionSender(sideChainWeb3, this.logger, this.config);
+      const federationFactory = new FederationFactory();
+      const fedContract = await federationFactory.createInstance(this.config.mainchain, this.config.privateKey);
+      const from = await transactionSender.getAddress(this.config.privateKey);
+      const isMember = await fedContract.isMember(from);
+      if (!isMember) {
+        this.logger.warn(`This Federator addr:${from} is not part of the federation. Skipping to next scheduled poll.`)
+        return;
+      }
       this.logger.upsertContext('Retrie', this.getCurrentRetrie());
       try {
          while (this.numberOfRetries > 0) {
           const bridgeFactory = new BridgeFactory();
-          const federationFactory = new FederationFactory();
           const success: boolean = await this.run({
             sideChainConfig,
             sideChainWeb3,

--- a/federator/src/lib/Heartbeat.ts
+++ b/federator/src/lib/Heartbeat.ts
@@ -219,7 +219,8 @@ export class Heartbeat {
       const from = await this.transactionSender.getAddress(this.config.privateKey);
       const isMember = await fedContract.isMember(from);
       if (!isMember) {
-        throw new Error(`This Federator addr:${from} is not part of the federation`);
+        this.logger.warn(`This Federator addr:${from} is not part of the federation`)
+        return;
       }
 
       this.logger.info(`emitHeartbeat(${fedVersion}, ${fedChainsIds}, ${fedChainsBlocks}, ${fedChainInfo})`);

--- a/federator/src/lib/Heartbeat.ts
+++ b/federator/src/lib/Heartbeat.ts
@@ -220,7 +220,7 @@ export class Heartbeat {
       const isMember = await fedContract.isMember(from);
       if (!isMember) {
         this.logger.warn(`This Federator addr:${from} is not part of the federation`)
-        return;
+        return false;
       }
 
       this.logger.info(`emitHeartbeat(${fedVersion}, ${fedChainsIds}, ${fedChainsBlocks}, ${fedChainInfo})`);

--- a/federator/src/main.ts
+++ b/federator/src/main.ts
@@ -159,7 +159,10 @@ export class Main {
     this.heartBeatScheduler = new Scheduler(heartBeatPollingInterval, this.logger, {
       run: async () => {
         try {
-          await this.heartbeat.run();
+          const result = await this.heartbeat.run();
+          if (!result) {
+            this.logger.warn("Heartbeat run run was not successful.")
+          }
         } catch (err) {
           this.logger.error('Unhandled Error on runHeartbeat()', err);
           process.exit(1);


### PR DESCRIPTION
### Give a warning when addres is not part of the fed

Currently the  Heartbeat process trys to emit the heart beat in the blockchain as we are not part of the federation it throws an error and retries 3 times after that the process is shut down.

To fix it prior to this, we should ask if the federator is part of the federation, if it’s not, we should log a warning and skip the rest.

Expected behaviour is that if we are not part of the federation we log a warning and continue syncing without actually calling the bridge or emiting the events.

### Description

- Replace the trigger of an error on the heartbeat event emit when the current address is not part of the federation. Instead, give a warning and skip emitting
- Skip running the current chain when the address derivated from the configured pk is not member of the federation

### How to Test

- Run the federator using a pk that is not part of the federator:
- The emit heartbeat process should not give an error anymore, and should instead display a warning indicating that the user is not part of the federation
- The runAll logic should skip processing messages until the user has become part of the federation
